### PR TITLE
Ensure the settings link on the plugin list screen goes to the new settings page

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -90,8 +90,8 @@ add_action( 'init', 'mailchimp_sf_plugin_init' );
  * @return array - Links
  */
 function mailchimp_sf_plugin_action_links( $links ) {
-	$settings_page = add_query_arg( array( 'page' => 'mailchimp_sf_options' ), admin_url( 'options-general.php' ) );
-	$settings_link = '<a href="' . esc_url( $settings_page ) . '">' . __( 'Settings', 'mailchimp_i18n' ) . '</a>';
+	$settings_page = add_query_arg( array( 'page' => 'mailchimp_sf_options' ), admin_url( 'admin.php' ) );
+	$settings_link = '<a href="' . esc_url( $settings_page ) . '">' . esc_html__( 'Settings', 'mailchimp_i18n' ) . '</a>';
 	array_unshift( $links, $settings_link );
 	return $links;
 }


### PR DESCRIPTION
### Description of the Change

In #29 we changed the location of the plugins settings page. In testing, I found the `Settings` link that we show on the plugin list view was still pointing to the old location. This PR updates that link.

Closes #32 

### How to test the Change

1. Go to `wp-admin/plugins.php`
2. Ensure the Mailchimp plugin is active
3. Click on the Settings link under the Mailchimp plugin
4. Ensure the proper settings page loads

### Changelog Entry

> Fixed - Ensure the plugin settings link goes to the right place

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
