### PR TITLE
Ensure consistent header and sub header spacing between block and shortcode output

### DIFF
--- a/mailchimp_widget.php
+++ b/mailchimp_widget.php
@@ -45,9 +45,12 @@ function mailchimp_sf_signup_form( $args = array() ) {
 		<?php
 		if ( ! empty( $after_widget ) ) {
 			echo wp_kses_post( $after_widget );
-		} else {
+		}
+
+		if ( empty( $before_widget ) ) {
 			echo '</div>';
 		}
+
 		return;
 	}
 
@@ -284,7 +287,9 @@ function mailchimp_sf_signup_form( $args = array() ) {
 	<?php
 	if ( ! empty( $after_widget ) ) {
 		echo wp_kses_post( $after_widget );
-	} else {
+	}
+
+	if ( empty( $before_widget ) ) {
 		echo '</div>';
 	}
 }


### PR DESCRIPTION
### Description of the Change

 As described here, there's a slight difference in spacing when using the shortcode block vs the normal block. This will vary based on the theme you're using, as this spacing isn't something we are adding. But in testing some of the core themes, what's happening here is the shortcode output does not have a wrapping container around things and there's some styling that gets applied to all direct children of the main content area.

This PR fixes things by adding in a wrapping container if a custom container isn't being used (when used as a normal widget in a widget area, there is already a wrapper so we don't want to double wrap). This removes this extra spacing. We also are adding some top margin on the sub-header to match the bottom margin that already existed there.

Partially closes #37 

<img width="674" alt="Block output" src="https://github.com/mailchimp/wordpress/assets/916738/81a9d08f-c6ed-42bd-bde3-dc46fe8a8964">

<img width="669" alt="Shortcode output" src="https://github.com/mailchimp/wordpress/assets/916738/a6b7b543-a27c-4072-93e4-cc135e1b3bae">

### How to test the Change

1. Install, activate and configure the plugin
2. Create a new page and add a Mailchimp Block and a Shortcode Block with the Mailchimp shortcode
3. View things on the front-end and note that there should be a container around both blocks and the spacing between the header and sub-header should match
4. If desired, use a widget enabled theme and add the Mailchimp widget into a widget area. Ensure things display correctly there as well

### Changelog Entry

> Fixed - Ensure the custom block and shortcode both have consistent spacing

### Credits

Props @dkotter, @qasumitbagthariya 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
