### PR TITLE
Make the API authentication error message more general.

### DIFF
--- a/lib/mailchimp/mailchimp.php
+++ b/lib/mailchimp/mailchimp.php
@@ -128,6 +128,7 @@ class MailChimp_API {
 			// Check if Access Token is invalid/revoked.
 			if ( in_array( $request['response']['code'], array( 401, 403 ), true ) ) {
 				update_option( 'mailchimp_sf_auth_error', true );
+				return new WP_Error( 'mailchimp-auth-error', esc_html__( 'Authentication failed.', 'mailchimp' ) );
 			}
 
 			$error = json_decode( $request['body'], true );


### PR DESCRIPTION
### Description of the Change
The PR updates the authentication error message to be more generic so that it can cover errors for both API key and access token authentication.

![image](https://github.com/user-attachments/assets/7414f229-ea70-4849-bd14-633c2f694f8a)


Closes #49 

### How to test the Change
1. Authenticate via the new OAuth flow
2. In the database, modify the mailchimp_sf_access_token value to make it invalid
3.  Refresh the settings page to see the error message and make sure it says "Authentication failed."

### Changelog Entry
> Changed - Make the API authentication error message more general.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
