### PR TITLE
Ensure the field name is properly added to the error message when the email address is blank.

### DIFF
--- a/lib/mailchimp/mailchimp.php
+++ b/lib/mailchimp/mailchimp.php
@@ -190,11 +190,16 @@ class MailChimp_API {
 					// Email address doesn't come back from the API, so if something's wrong, it's that.
 					$field_name                   = esc_html__( 'Email Address', 'mailchimp' );
 					$body['errors'][0]['message'] = esc_html__( 'Please fill out a valid email address.', 'mailchimp' );
+				} elseif ( ! empty( $body['errors'] ) && isset( $body['errors'][0]['field'] ) && 'email_address' === $body['errors'][0]['field'] ) {
+					$field_name = esc_html__( 'Email Address', 'mailchimp' );
 				} elseif ( ! empty( $body['errors'] ) && isset( $body['errors'][0]['field'] ) && $merge['tag'] === $body['errors'][0]['field'] ) {
 					$field_name = $merge['name'];
 				}
 			}
-			$message = sprintf( $field_name . ': ' . $body['errors'][0]['message'] );
+			$message = $body['errors'][0]['message'];
+			if ( ! empty ( $field_name ) ) {
+				$message = $field_name . ': ' . $body['errors'][0]['message'];
+			}
 			return new WP_Error( 'mc-subscribe-error-api', $message );
 		}
 	}

--- a/lib/mailchimp/mailchimp.php
+++ b/lib/mailchimp/mailchimp.php
@@ -196,10 +196,9 @@ class MailChimp_API {
 					$field_name = $merge['name'];
 				}
 			}
-			$message = $body['errors'][0]['message'];
-			if ( ! empty ( $field_name ) ) {
-				$message = $field_name . ': ' . $body['errors'][0]['message'];
-			}
+			$message = $body['errors'][0]['message'] ?? esc_html__( 'Something went wrong, Please try again later.', 'mailchimp' );
+			$message = ( ! empty( $field_name ) ) ? $field_name . ': ' . $message : $message;
+
 			return new WP_Error( 'mc-subscribe-error-api', $message );
 		}
 	}

--- a/tests/cypress/e2e/settings.test.js
+++ b/tests/cypress/e2e/settings.test.js
@@ -35,7 +35,7 @@ describe('Admin can update plugin settings', () => {
 				cy.get('#mc_signup_submit').should('exist');
 				cy.get('#mc_signup_submit').click();
 				cy.get('.mc_error_msg').should('exist');
-				cy.get('.mc_error_msg').contains(': This value should not be blank.');
+				cy.get('.mc_error_msg').contains('Email Address: This value should not be blank.');
 			}
 		});
 	});
@@ -55,7 +55,7 @@ describe('Admin can update plugin settings', () => {
 				cy.get('#mc_signup_submit').should('exist');
 				cy.get('#mc_signup_submit').click();
 				cy.get('.mc_error_msg').should('exist');
-				cy.get('.mc_error_msg').contains(': This value should not be blank.');
+				cy.get('.mc_error_msg').contains('Email Address: This value should not be blank.');
 			}
 		});
 	});


### PR DESCRIPTION
### Description of the Change
As reported in #73, when attempting to submit the subscribe form without entering an email address, the error message did not include the field name, causing confusion about which field is incorrect and what needs to be fixed to submit the form successfully. 

This PR introduces a minor fix to properly identify the field with the error, making the error message clear and specifically linked to the relevant form field.

Closes #73 

### How to test the Change
1. Install and set up the plugin.
1. Add the subscribe form using a block, widget, or shortcode.
1. Visit the subscription form page on the front end, and click "Subscribe" without entering an email address.
1. Ensure the error message is clear, identifies the field with the issue, and describes the related error.

### Changelog Entry
> Fixed - Ensure the field name is properly added to the error message when the email address is blank.

### Credits
Props @jerclarke, @iamdharmesh

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
