### PR TITLE
Enhancement/shortcode conversion to block

### DIFF
--- a/includes/blocks/mailchimp/index.js
+++ b/includes/blocks/mailchimp/index.js
@@ -11,6 +11,9 @@ registerBlockType(metadata, {
 			{
 				type: 'shortcode',
 				tag: 'mailchimpsf_form',
+				attributes: {
+					// No attributes, but attributes property is required
+				},
 			},
 		],
 	},

--- a/includes/blocks/mailchimp/index.js
+++ b/includes/blocks/mailchimp/index.js
@@ -6,6 +6,14 @@ import Icon from './icon';
 
 registerBlockType(metadata, {
 	icon: Icon,
+	transforms: {
+		from: [
+			{
+				type: 'shortcode',
+				tag: 'mailchimpsf_form',
+			},
+		],
+	},
 	edit: BlockEdit,
 	save: () => null,
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When a user opens a classic post in the Gutenberg Block Editor there is a "Convert to blocks" option that transforms the Mailchimp `mailchimp_sf_shortcode` shortcode to a Gutenberg block.
![mailchimp-shortcode-transform-to-block](https://github.com/user-attachments/assets/cf133bbe-15c3-44d8-a0ef-5b5dc7ef14ff)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #64 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- Create a post with classic editor on
- Insert mailchimp shortcode
- Turn classic editor off
- Open post in block editor
- Click "Convert to blocks" button
- Shortcode should be transformed into a Gutenberg Mailchimp block

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Transform from `mailchimp_sf_shortcode` shortcode to a Gutenberg block

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [x] ~I have updated the documentation accordingly.~ No documentation to update
- [x] ~I have added tests to cover my change.~ Small changes using native WP functionality. Limited risk with no attributes to transfer. No changes necessary.
- [ ] All new and existing tests pass. - **Having trouble running cypress tests on WSL2**
