### PR TITLE
Enhancement/update success error messages to wp admin notices

### DIFF
--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Admin notices.
+ *
+ * @package Mailchimp
+ */
+
+/**
+ * Display success admin notice.
+ *
+ * NOTE: WordPress localization i18n functionality should be done
+ * on string literals outside of this function in order to work
+ * correctly.
+ *
+ * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ *
+ * @since 1.7.0
+ * @param string $msg The message to display.
+ * @return void
+ */
+function mailchimp_sf_admin_notice_success( string $msg ): void {
+	?>
+	<div class="notice notice-success is-dismissible">
+		<p><?php echo esc_html( $msg ); ?></p>
+	</div>
+	<?php
+}
+
+/**
+ * Display error admin notice.
+ *
+ * NOTE: WordPress localization i18n functionality should be done
+ * on string literals outside of this function in order to work
+ * correctly.
+ *
+ * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ *
+ * @since 1.7.0
+ * @param string $msg The message to display.
+ * @return void
+ */
+function mailchimp_sf_admin_notice_error( string $msg ): void {
+	?>
+	<div class="notice notice-error">
+		<p><?php echo esc_html( $msg ); ?></p>
+	</div>
+	<?php
+}

--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -21,7 +21,22 @@
 function mailchimp_sf_admin_notice_success( string $msg ): void {
 	?>
 	<div class="notice notice-success is-dismissible">
-		<p><?php echo esc_html( $msg ); ?></p>
+		<p>
+		<?php
+		echo wp_kses(
+			$msg,
+			array(
+				'a'      => array(
+					'href'   => array(),
+					'title'  => array(),
+					'target' => array(),
+				),
+				'strong' => array(),
+				'em'     => array(),
+			)
+		);
+		?>
+		</p>
 	</div>
 	<?php
 }
@@ -42,7 +57,22 @@ function mailchimp_sf_admin_notice_success( string $msg ): void {
 function mailchimp_sf_admin_notice_error( string $msg ): void {
 	?>
 	<div class="notice notice-error">
-		<p><?php echo esc_html( $msg ); ?></p>
+		<p>
+		<?php
+		echo wp_kses(
+			$msg,
+			array(
+				'a'      => array(
+					'href'   => array(),
+					'title'  => array(),
+					'target' => array(),
+				),
+				'strong' => array(),
+				'em'     => array(),
+			)
+		);
+		?>
+		</p>
 	</div>
 	<?php
 }

--- a/includes/class-mailchimp-admin.php
+++ b/includes/class-mailchimp-admin.php
@@ -38,6 +38,26 @@ class Mailchimp_Admin {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_page_scripts' ) );
 		add_action( 'admin_menu', array( $this, 'add_create_account_page' ) );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ) );
+
+		// TODO: Should this load somewhere else?
+		$this->require_admin_utils();
+	}
+
+	/**
+	 * Require admin utils.
+	 *
+	 * Currently includes admin notices from a single file. Long term plan is to break up admin
+	 * functionality into smaller, more focused files to improve maintainability. This could also include:
+	 * - Moving OAuth related code to oauth.php
+	 * - Moving account creation code to account.php
+	 * - Moving settings page code to settings.php
+	 * - Moving notices code to notices.php (already done)
+	 * This will help avoid having too much code in a single file and make the codebase more modular.
+	 *
+	 * @since 1.7.0
+	 */
+	private function require_admin_utils() {
+		include_once MCSF_DIR . 'includes/admin/admin-notices.php';
 	}
 
 	/**

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -429,6 +429,9 @@ function mailchimp_sf_delete_setup() {
 /**
  * Gets or sets a global message based on parameter passed to it
  *
+ * On the plugin settings page, WP admin notices are displayed
+ * instead of the global message.
+ *
  * @param mixed $msg Message
  * @return string/bool depending on get/set
  */
@@ -448,44 +451,6 @@ function mailchimp_sf_global_msg( $msg = null ) {
 	// Must be setting
 	$mcsf_msgs[] = $msg;
 	return true;
-}
-
-/**
- * Display success admin notice.
- * 
- * NOTE: WordPress localization i18n functionality should be done
- * on string literals outside of this function in order to work
- * correctly.
- * 
- * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
- *
- * @since 1.7.0
- */
-function mailchimp_sf_admin_notice_success( string $msg ): void {
-	?>
-	<div class="notice notice-success is-dismissible">
-		<p><?php echo $msg; ?></p>
-	</div>
-	<?php
-}
-
-/**
- * Display error admin notice.
- * 
- * NOTE: WordPress localization i18n functionality should be done
- * on string literals outside of this function in order to work
- * correctly.
- * 
- * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
- *
- * @since 1.7.0
- */
-function mailchimp_sf_admin_notice_error( string $msg ): void {
-	?>
-	<div class="notice notice-error">
-		<p><?php echo $msg; ?></p>
-	</div>
-	<?php
 }
 
 /**
@@ -712,12 +677,12 @@ function mailchimp_sf_change_list_if_necessary() {
 			}
 
 			$msg = sprintf(
-						/* translators: %s: count (number) */
-						__( '<b>Success!</b> Loaded and saved the info for %d Merge Variables', 'mailchimp' ) . $igs_text,
-						count( $mv )
-					) . ' ' .
-					esc_html__( 'from your list' ) . ' "' . $list_name . '"<br/><br/>' .
-					esc_html__( 'Now you should either Turn On the Mailchimp Widget or change your options below, then turn it on.', 'mailchimp' );
+				/* translators: %s: count (number) */
+				__( '<b>Success!</b> Loaded and saved the info for %d Merge Variables', 'mailchimp' ) . $igs_text,
+				count( $mv )
+			) . ' ' .
+			esc_html__( 'from your list' ) . ' "' . $list_name . '"<br/><br/>' .
+			esc_html__( 'Now you should either Turn On the Mailchimp Widget or change your options below, then turn it on.', 'mailchimp' );
 
 			mailchimp_sf_admin_notice_success( $msg );
 		}

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -451,6 +451,44 @@ function mailchimp_sf_global_msg( $msg = null ) {
 }
 
 /**
+ * Display success admin notice.
+ * 
+ * NOTE: WordPress localization i18n functionality should be done
+ * on string literals outside of this function in order to work
+ * correctly.
+ * 
+ * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ *
+ * @since 1.7.0
+ */
+function mailchimp_sf_admin_notice_success( string $msg ): void {
+	?>
+	<div class="notice notice-success is-dismissible">
+		<p><?php echo $msg; ?></p>
+	</div>
+	<?php
+}
+
+/**
+ * Display error admin notice.
+ * 
+ * NOTE: WordPress localization i18n functionality should be done
+ * on string literals outside of this function in order to work
+ * correctly.
+ * 
+ * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ *
+ * @since 1.7.0
+ */
+function mailchimp_sf_admin_notice_error( string $msg ): void {
+	?>
+	<div class="notice notice-error">
+		<p><?php echo $msg; ?></p>
+	</div>
+	<?php
+}
+
+/**
  * Sets the default options for the option form
  *
  * @param string $list_name The Mailchimp list name.
@@ -486,65 +524,65 @@ function mailchimp_sf_save_general_form_settings() {
 	// IF NOT DEV MODE
 	if ( isset( $_POST['mc_use_javascript'] ) ) {
 		update_option( 'mc_use_javascript', 'on' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Fancy Javascript submission turned On!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Fancy Javascript submission turned On!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_use_javascript' ) !== 'off' ) {
 		update_option( 'mc_use_javascript', 'off' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Fancy Javascript submission turned Off!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Fancy Javascript submission turned Off!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	if ( isset( $_POST['mc_use_datepicker'] ) ) {
 		update_option( 'mc_use_datepicker', 'on' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Datepicker turned On!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Datepicker turned On!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_use_datepicker' ) !== 'off' ) {
 		update_option( 'mc_use_datepicker', 'off' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Datepicker turned Off!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Datepicker turned Off!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	/*Enable double optin toggle*/
 	if ( isset( $_POST['mc_double_optin'] ) ) {
 		update_option( 'mc_double_optin', true );
-		$msg = '<p class="success_msg">' . esc_html__( 'Double opt-in turned On!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Double opt-in turned On!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_double_optin' ) !== false ) {
 		update_option( 'mc_double_optin', false );
-		$msg = '<p class="success_msg">' . esc_html__( 'Double opt-in turned Off!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Double opt-in turned Off!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	/* NUKE the CSS! */
 	if ( isset( $_POST['mc_nuke_all_styles'] ) ) {
 		update_option( 'mc_nuke_all_styles', true );
-		$msg = '<p class="success_msg">' . esc_html__( 'Mailchimp CSS turned Off!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Mailchimp CSS turned Off!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_nuke_all_styles' ) !== false ) {
 		update_option( 'mc_nuke_all_styles', false );
-		$msg = '<p class="success_msg">' . esc_html__( 'Mailchimp CSS turned On!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Mailchimp CSS turned On!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	/* Update existing */
 	if ( isset( $_POST['mc_update_existing'] ) ) {
 		update_option( 'mc_update_existing', true );
-		$msg = '<p class="success_msg">' . esc_html__( 'Update existing subscribers turned On!' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Update existing subscribers turned On!' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_update_existing' ) !== false ) {
 		update_option( 'mc_update_existing', false );
-		$msg = '<p class="success_msg">' . esc_html__( 'Update existing subscribers turned Off!' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Update existing subscribers turned Off!' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	if ( isset( $_POST['mc_use_unsub_link'] ) ) {
 		update_option( 'mc_use_unsub_link', 'on' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Unsubscribe link turned On!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Unsubscribe link turned On!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	} elseif ( get_option( 'mc_use_unsub_link' ) !== 'off' ) {
 		update_option( 'mc_use_unsub_link', 'off' );
-		$msg = '<p class="success_msg">' . esc_html__( 'Unsubscribe link turned Off!', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Unsubscribe link turned Off!', 'mailchimp' );
+		mailchimp_sf_admin_notice_success( $msg );
 	}
 
 	$content = isset( $_POST['mc_header_content'] ) ? wp_kses_post( wp_unslash( $_POST['mc_header_content'] ) ) : '';
@@ -601,8 +639,8 @@ function mailchimp_sf_save_general_form_settings() {
 		}
 	}
 
-	$msg = '<p class="success_msg">' . esc_html__( 'Successfully Updated your List Subscribe Form Settings!', 'mailchimp' ) . '</p>';
-	mailchimp_sf_global_msg( $msg );
+	$msg = esc_html__( 'Successfully Updated your List Subscribe Form Settings!', 'mailchimp' );
+	mailchimp_sf_admin_notice_success( $msg );
 }
 
 /**
@@ -614,8 +652,8 @@ function mailchimp_sf_change_list_if_necessary() {
 	}
 
 	if ( empty( $_POST['mc_list_id'] ) ) {
-		$msg = '<p class="error_msg">' . esc_html__( 'Please choose a valid list', 'mailchimp' ) . '</p>';
-		mailchimp_sf_global_msg( $msg );
+		$msg = esc_html__( 'Please choose a valid list', 'mailchimp' );
+		mailchimp_sf_admin_notice_error( $msg );
 		return;
 	}
 
@@ -673,16 +711,15 @@ function mailchimp_sf_change_list_if_necessary() {
 				$igs_text .= sprintf( esc_html__( 'and %s Sets of Interest Groups', 'mailchimp' ), count( $igs ) );
 			}
 
-			$msg = '<p class="success_msg">' .
-				sprintf(
-					/* translators: %s: count (number) */
-					__( '<b>Success!</b> Loaded and saved the info for %d Merge Variables', 'mailchimp' ) . $igs_text,
-					count( $mv )
-				) . ' ' .
-				esc_html__( 'from your list' ) . ' "' . $list_name . '"<br/><br/>' .
-				esc_html__( 'Now you should either Turn On the Mailchimp Widget or change your options below, then turn it on.', 'mailchimp' ) . '</p>';
+			$msg = sprintf(
+						/* translators: %s: count (number) */
+						__( '<b>Success!</b> Loaded and saved the info for %d Merge Variables', 'mailchimp' ) . $igs_text,
+						count( $mv )
+					) . ' ' .
+					esc_html__( 'from your list' ) . ' "' . $list_name . '"<br/><br/>' .
+					esc_html__( 'Now you should either Turn On the Mailchimp Widget or change your options below, then turn it on.', 'mailchimp' );
 
-			mailchimp_sf_global_msg( $msg );
+			mailchimp_sf_admin_notice_success( $msg );
 		}
 	}
 }

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -253,7 +253,7 @@ function mailchimp_sf_request_handler() {
 						if ( ! headers_sent() ) { // just in case...
 							header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT', true, 200 );
 						}
-						echo wp_kses_post( mailchimp_sf_global_msg() );
+						echo wp_kses_post( mailchimp_sf_frontend_msg() );
 						exit;
 				}
 		}
@@ -296,7 +296,7 @@ function mailchimp_sf_migrate_sopresto() {
 			$api = new MailChimp_API( $key->response );
 		} catch ( Exception $e ) {
 			$msg = '<strong class="mc_error_msg">' . $e->getMessage() . '</strong>';
-			mailchimp_sf_global_msg( $msg );
+			mailchimp_sf_frontend_msg( $msg );
 			return;
 		}
 
@@ -427,15 +427,17 @@ function mailchimp_sf_delete_setup() {
 }
 
 /**
- * Gets or sets a global message based on parameter passed to it
+ * Gets or sets a frontend message based on parameter passed to it
  *
- * On the plugin settings page, WP admin notices are displayed
- * instead of the global message.
+ * Used to convey error messages to the user outside of the WP Admin
+ *
+ * On the plugin settings page, WP admin notices are used exclusively
+ * instead of the frontend message.
  *
  * @param mixed $msg Message
  * @return string/bool depending on get/set
  */
-function mailchimp_sf_global_msg( $msg = null ) {
+function mailchimp_sf_frontend_msg( $msg = null ) {
 	global $mcsf_msgs;
 
 	// Make sure we're formed properly
@@ -858,7 +860,7 @@ function mailchimp_sf_signup_submit() {
 	// Catch errors and fail early.
 	if ( is_wp_error( $merge ) ) {
 		$msg = '<strong class="mc_error_msg">' . $merge->get_error_message() . '</strong>';
-		mailchimp_sf_global_msg( $msg );
+		mailchimp_sf_frontend_msg( $msg );
 
 		return false;
 	}
@@ -899,7 +901,7 @@ function mailchimp_sf_signup_submit() {
 				]
 			)
 		);
-		mailchimp_sf_global_msg( $error );
+		mailchimp_sf_frontend_msg( $error );
 		return false;
 	}
 
@@ -910,7 +912,7 @@ function mailchimp_sf_signup_submit() {
 	if ( get_option( 'mc_update_existing' ) === false && 'subscribed' === $status ) {
 		$msg   = esc_html__( 'This email address is already subscribed to the list.', 'mailchimp' );
 		$error = new WP_Error( 'mailchimp-update-existing', $msg );
-		mailchimp_sf_global_msg( '<strong class="mc_error_msg">' . $msg . '</strong>' );
+		mailchimp_sf_frontend_msg( '<strong class="mc_error_msg">' . $msg . '</strong>' );
 		return false;
 	}
 
@@ -920,7 +922,7 @@ function mailchimp_sf_signup_submit() {
 	// If we have errors, then show them
 	if ( is_wp_error( $retval ) ) {
 		$msg = '<strong class="mc_error_msg">' . $retval->get_error_message() . '</strong>';
-		mailchimp_sf_global_msg( $msg );
+		mailchimp_sf_frontend_msg( $msg );
 		return false;
 	}
 
@@ -933,7 +935,7 @@ function mailchimp_sf_signup_submit() {
 	}
 
 	// Set our global message
-	mailchimp_sf_global_msg( $msg );
+	mailchimp_sf_frontend_msg( $msg );
 
 	return true;
 }

--- a/mailchimp_widget.php
+++ b/mailchimp_widget.php
@@ -184,7 +184,7 @@ function mailchimp_sf_signup_form( $args = array() ) {
 	<div class="mc_form_inside">
 
 		<div class="updated" id="mc_message">
-			<?php echo wp_kses_post( mailchimp_sf_global_msg() ); ?>
+			<?php echo wp_kses_post( mailchimp_sf_frontend_msg() ); ?>
 		</div><!-- /mc_message -->
 
 		<?php

--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -15,14 +15,6 @@ $is_list_selected = false;
 ?>
 <div class="wrap">
 	<hr class="wp-header-end" />
-	<?php
-	// Display our success/error message(s) if have them
-	if ( mailchimp_sf_global_msg() !== '' ) {
-		?>
-		<div id="mc-message" class=""><?php echo wp_kses_post( mailchimp_sf_global_msg() ); ?></div>
-		<?php
-	}
-	?>
 	<table class="mc-user" cellspacing="0">
 		<tr>
 			<td><h3><?php esc_html_e( 'Logged in as', 'mailchimp' ); ?>: <?php echo esc_html( $user['username'] ); ?></h3>

--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -54,29 +54,19 @@ $is_list_selected = false;
 			// we *could* support paging, but few users have that many lists (and shouldn't)
 			$lists = $api->get( 'lists', 100, array( 'fields' => 'lists.id,lists.name,lists.email_type_option' ) );
 			if ( is_wp_error( $lists ) ) {
-				?>
-				<div class="error_msg">
-					<?php
-					printf(
-						/* translators: %s: error message */
-						esc_html__( 'Uh-oh, we couldn\'t get your lists from Mailchimp! Error: %s', 'mailchimp' ),
-						esc_html( $lists->get_error_message() )
-					);
-					?>
-				</div>
-				<?php
+				$msg = sprintf(
+					/* translators: %s: error message */
+					esc_html__( 'Uh-oh, we couldn\'t get your lists from Mailchimp! Error: %s', 'mailchimp' ),
+					esc_html( $lists->get_error_message() )
+				);
+				mailchimp_sf_admin_notice_error( $msg );
 			} elseif ( isset( $lists['lists'] ) && count( $lists['lists'] ) === 0 ) {
-				?>
-				<div class="error_msg">
-					<?php
-					printf(
-						/* translators: %s: link to Mailchimp */
-						esc_html__( 'Uh-oh, you don\'t have any lists defined! Please visit %s, login, and setup a list before using this tool!', 'mailchimp' ),
-						"<a href='http://www.mailchimp.com/'>Mailchimp</a>"
-					);
-					?>
-				</div>
-				<?php
+				$msg = sprintf(
+					/* translators: %s: link to Mailchimp */
+					esc_html__( 'Uh-oh, you don\'t have any lists defined! Please visit %s, login, and setup a list before using this tool!', 'mailchimp' ),
+					"<a href='http://www.mailchimp.com/'>Mailchimp</a>"
+				);
+				mailchimp_sf_admin_notice_error( $msg );
 			} else {
 				$lists            = $lists['lists'];
 				$option           = get_option( 'mc_list_id' );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

## Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

On the plugin settings page, replace the custom Mailchimp UI for admin notices to the standard WP admin notices API

![mailchimp-messages-to-wp-admin-notices](https://github.com/user-attachments/assets/53c56c99-44e5-4fd4-8fd3-90135cdf4c96)

### Drawbacks

- Two systems for displaying messages. WP admin notices and the Mailchimp custom messages for the front end.

### Possible regressions
While I've tested for all of these scenarios and fixed any issues I've found the following items are the most likely regressions.

- It's possible that some messages that should display as WP admin notices were missed and will still display as custom Mailchimp messages
  - It's possible that those messages that were not updated will not display at all due to removing custom message output on the plugin settings page
- It's possible that specialized message text will be stripped out by sanitization functions that have been introduced or tweaked

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #62 

## How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### WP Admin messages
A video recording can be made on request for any of the testing items below.

I've documented all of the possible testing scenarios that I found while making the changes, but due to the extensive list of areas to test I recommend making a note of any items that are too difficult or time consuming to efficiently test. We can then look at the items that were not tested and decide on a plan.

For example, testing the error message for an invalid Mailchimp API token would require finding a way to fail the OAuth flow while still navigating to the plugin settings page. It might be better to talk about items like that and brainstorm easier ways of ensuring regression proof code, such as relying on the OAuth test in `/tests/cypress/e2e/connect.test.js` or extending it.

![image](https://github.com/user-attachments/assets/f28c6742-7b90-4c69-bccb-18d19aaa8146)

#### Success message

Settings page URL: `/wp-admin/admin.php?page=mailchimp_sf_options`

- Save any option and the success message will display
  - (optional) If we really want to go above and beyond we could save every single option on the page to trigger all of the locations where the success message will display
  - Pro tip: Multiple admin notices will display at the same time. You can turn every option on and then every option off again. Caution should be taken for options that will conditionally hide or display other options.

#### Error message

- Set the users list to "-- Select a List --" and click "Update List"
- If a users lists can not be retrieved from Mailchimp then an error will display
- If a user does not have any lists in their Mailchimp account defined then an error will display

### FE messages
**FE messages should remain unchanged**

![image](https://github.com/user-attachments/assets/960812ef-81a1-4bd7-899f-2f16403d3a25)

#### Success Messages
Submit the form after filling out all required fields to trigger the success message

- Users that already exist as a contact will be subscribed without email verification required (I think)
- Users not already saved as a contact will receive a success message to verify their email

#### Error Messages
Submit the form without entering any details to trigger the error message
The following scenarios will also throw errors on the FE

- Required fields not filled out or invalid
- If Mailchimp API client won't work (invalid token, etc) then an error will be thrown
- If update existing is turned off in the plugin settings and the subscriber email already exists then an error will be thrown
- Error with API request adding subscriber to list (could trigger with chrome dev tools -> mobile device view -> go offline)

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Plugin settings page success and error messages will now use WP admin notices

## Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
