### PR TITLE
Bug/when US phone is not included as a merge field in a Mailchimp form it causes fatal error on submission

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -1004,7 +1004,12 @@ function mailchimp_sf_merge_submit( $mv ) {
 		$opt_val = isset( $_POST[ $opt ] ) ? map_deep( stripslashes_deep( $_POST[ $opt ] ), 'sanitize_text_field' ) : '';
 
 		// Handle phone number logic
-		if ( isset( $mv_var['options']['phone_format'] ) && 'phone' === $mv_var['type'] && 'US' === $mv_var['options']['phone_format'] ) {
+		if (
+			'phone' === $mv_var['type'] && // Merge field is phone
+			'on' === get_option( $opt ) && // Merge field is "included" in the Mailchimp admin options
+			isset( $mv_var['options']['phone_format'] ) && // Phone format is set in Mailchimp account
+			'US' === $mv_var['options']['phone_format'] // Phone format is US in Mailchimp account
+		) {
 			$opt_val = mailchimp_sf_merge_validate_phone( $opt_val, $mv_var );
 			if ( is_wp_error( $opt_val ) ) {
 				return $opt_val;

--- a/tests/cypress/e2e/connect.test.js
+++ b/tests/cypress/e2e/connect.test.js
@@ -23,6 +23,18 @@ describe('Admin can connect to "Mailchimp" Account', () => {
 		cy.get('#mailchimp_sf_oauth_connect').click();
 		cy.wait(6000);
 
+		// Accept cookie consent popup window (if present)
+		cy.popup().then(($popup) => {
+			const acceptButtonSelector = '#onetrust-accept-btn-handler';
+
+			// Check if the accept button is visible and click it
+			if ($popup.find(acceptButtonSelector).length > 0 && $popup.find(acceptButtonSelector).is(':visible')) {
+				$popup.find(acceptButtonSelector).click();
+			} else {
+				cy.log('Cookie consent popup not found or not visible.');
+			}
+		});
+
 		cy.popup()
 			.find('input#username')
 			.clear()


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Fixed a bug causing a fatal PHP error when:
- Phone number is set to US style in the Mailchimp account
- Phone number is NOT included as a merge field in the WP plugin

https://github.com/user-attachments/assets/d9ce47ee-6e25-4997-9a4f-96ea6e9ca2d3

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #103 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

The video `us-phone-fatal-error-when-merge-field-not-included.mov` above can be used as a guide for recreating the testing conditions. However, instead of a fatal error you should see a successful form submission.

#### Phone number
1. Set the phone format in the test Mailchimp account (/lists/settings/merge-tags) to US style
2. Select the "Update List" button to refresh the Mailchimp data with WP
3. Ensure that Phone Number is not an included merge field. The error will only occur when Phone Number is not included in the form.
4. Submit a form submission using only email (any merge field is okay and the error should occur regardless)
5. The form submission should submit successfully

#### Address
I added a conditional check to ensure address fields were included for submission.

##### With address
1. Include address in the Mailchimp admin
2. Fill out and submit a form
3. The form submission should be successful

##### Without address
1. Ensure that address is NOT included in the Mailchimp admin
2. Fill out and submit a form
3. The form submission should be successful

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal PHP error that would occur when the phone merge field was set to US format, but the merge field was not included in the Mailchimp plugin.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my change.~~ Small change, not worth writing tests
- [x] All new and existing tests pass.
