### PR TITLE
Bug/required field does not display as required in the WP Mailchimp settings page

### DIFF
--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -300,7 +300,7 @@ $is_list_selected = false;
 							<tr valign="top">
 								<td><?php echo esc_html( $mv_var['name'] ); ?></td>
 								<td><?php echo esc_html( $mv_var['tag'] ); ?></td>
-								<td><?php echo esc_html( ( 1 === $mv_var['required'] ) ? 'Y' : 'N' ); ?></td>
+								<td><?php echo esc_html( ( 1 === intval( $mv_var['required'] ) ) ? 'Y' : 'N' ); ?></td>
 								<td>
 									<?php
 									if ( ! $mv_var['required'] ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
In order to avoid duplicating information, please see https://github.com/mailchimp/wordpress/issues/102 for a description of the original bug.

https://github.com/user-attachments/assets/ee921eac-8eea-44e6-8fd2-65b7e9c79e4a

#### Solution
Update strict equality comparison check to force the required field to have the same type. This fixes the bug and will cause merge fields to correctly display if they are required in the Mailchimp WP admin page.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #102 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
_This video in the "Description of the Change" demonstrating the original bug can be used as a walkthrough. However, instead of the bug you should see the fix._
1. Log into the test user Mailchimp account and set a sampling of the merge fields to required.
2. Log into the WordPress site -> navigate to the Mailchimp settings page -> Click "Update List" to refresh the Mailchimp data.
3. Navigate down to the merge field tags section. The required labels should reflect whether the field is or is not required in the Mailchimp account.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug causing merge fields on the Mailchimp WP admin page to incorrectly display as not required when they were, in fact, required.



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] ~~I have updated the documentation accordingly.~~ Small change, no documentation to update
- [ ] ~~I have added tests to cover my change.~~ Small change, not worth the test
- [ ] All new and existing tests pass.
