### PR TITLE
Bug/merge fields not marked as "Visible?" in the user's Mailchimp account will still display as includable in the WP Mailchimp settings page

### DIFF
--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -303,7 +303,7 @@ $is_list_selected = false;
 								<td><?php echo esc_html( ( 1 === $mv_var['required'] ) ? 'Y' : 'N' ); ?></td>
 								<td>
 									<?php
-									if ( ! $mv_var['required'] ) {
+									if ( ! $mv_var['required'] && $mv_var['public'] ) {
 										$opt = 'mc_mv_' . $mv_var['tag'];
 										?>
 										<label class="screen-reader-text" for="<?php echo esc_attr( $opt ); ?>">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
In order to avoid duplicating information, please see https://github.com/mailchimp/wordpress/issues/105 for a description of the original bug.

https://github.com/user-attachments/assets/42176186-39aa-4023-af47-1658b2c0f3f1

#### Solution
Add another conditional check to display the include checkboxes only when the merge field is public.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #105 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
_This video in the "Description of the Change" demonstrating the original bug can be used as a walkthrough. However, instead of the bug you should see the fix._

1. Uncheck the "Visible?" column in a sampling of merge fields in the test user Mailchimp account
2. On the Mailchimp WP settings page click "Update List" to refresh the data from Mailchimp
3. In the "Merge Fields Included" section, you should only see checkboxes for the merge fields that have the "Visible?" column checked in the Mailchimp account
4. (optional) Navigate to the front end to ensure that the non visible merge fields do not display.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fixed an issue that was allowing a user to select merge fields that were not selected as visible in the Mailchimp account.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] ~~I have updated the documentation accordingly.~~ No documentation to update
- [ ] ~~I have added tests to cover my change.~~ Small fix, no test needed
- [ ] All new and existing tests pass.
