### PR TITLE
Bug/double opt in triggered despite being disabled in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ tests/cypress/reports
 tests/cypress/downloads
 
 mailchimp.zip
+
+# IDE
+.vscode

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -971,8 +971,9 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 		return $body;
 	}
 
-	// Subscribe the user immediately unless double opt-in is enabled
-	// No need to check user $status because we're handling that before this point
+	// Subscribe the email immediately unless double opt-in is enabled
+	// "unsubscribed" and "subscribed" existing emails have been excluded at this stage
+	// "pending" emails should follow double opt-in rules
 	$body->status = $double_optin ? 'pending' : 'subscribed';
 
 	return $body;

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -944,8 +944,8 @@ function mailchimp_sf_signup_submit() {
  * @param [type] $igs Interest groups
  * @param string $email_type Email type
  * @param string $email Email
- * @param string $status Status
- * @param bool   $double_optin Whether this is double optin
+ * @param string|false $status Status The subscription status ('subscribed', 'unsubscribed', 'pending', etc.) or false if an error occurred.
+ * @param string $double_optin Whether double opt-in is enabled. "1" for enabled and "" for disabled.
  * @return stdClass
  */
 function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status, $double_optin ) {
@@ -953,6 +953,7 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 	$body->email_address = $email;
 	$body->email_type    = $email_type;
 	$body->merge_fields  = $merge;
+
 	if ( ! empty( $igs ) ) {
 		$body->interests = $igs;
 	}
@@ -970,10 +971,10 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 }
 
 /**
- * Check status.
+ * Check the status of a subscriber in the list.
  *
- * @param string $endpoint Endpoint.
- * @return string
+ * @param string $endpoint API endpoint to check the status.
+ * @return string|false The subscription status ('subscribed', 'unsubscribed', 'pending', etc.) or false if an error occurred.
  */
 function mailchimp_sf_check_status( $endpoint ) {
 	$endpoint  .= '?fields=status';

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -963,13 +963,8 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 		return $body;
 	}
 
-	// single opt-in that covers new subscribers
-	if ( false === ! $status && $double_optin ) {
-		$body->status = 'subscribed';
-	} else {
-		// anyone else
-		$body->status = 'pending';
-	}
+	// Subscribe the user immediately unless double opt-in is enabled
+	$body->status = $double_optin ? 'pending' : 'subscribed';
 
 	return $body;
 }
@@ -978,7 +973,7 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
  * Check the status of a subscriber in the list.
  *
  * @param string $endpoint API endpoint to check the status.
- * @return string|false The subscription status ('subscribed', 'unsubscribed', 'pending', etc.) or false if an error occurred.
+ * @return string|false The subscription status ('subscribed', 'unsubscribed', 'pending', etc.) or false if the API returned 404 or an error occurred.
  */
 function mailchimp_sf_check_status( $endpoint ) {
 	$endpoint  .= '?fields=status';

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -944,12 +944,12 @@ function mailchimp_sf_signup_submit() {
  * Cleans up merge fields and interests to make them
  * API 3.0-friendly.
  *
- * @param [type] $merge Merge fields
- * @param [type] $igs Interest groups
- * @param string $email_type Email type
- * @param string $email Email
+ * @param [type]       $merge Merge fields
+ * @param [type]       $igs Interest groups
+ * @param string       $email_type Email type
+ * @param string       $email Email
  * @param string|false $status Status The subscription status ('subscribed', 'unsubscribed', 'pending', etc.) or false if an error occurred.
- * @param string $double_optin Whether double opt-in is enabled. "1" for enabled and "" for disabled.
+ * @param string       $double_optin Whether double opt-in is enabled. "1" for enabled and "" for disabled.
  * @return stdClass
  */
 function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status, $double_optin ) {

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -958,15 +958,19 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 		$body->interests = $igs;
 	}
 
-	if ( 'subscribed' !== $status ) {
-		// single opt-in that covers new subscribers
-		if ( false === ! $status && $double_optin ) {
-			$body->status = 'subscribed';
-		} else {
-			// anyone else
-			$body->status = 'pending';
-		}
+	// Early return for already subscribed users
+	if ( 'subscribed' === $status ) {
+		return $body;
 	}
+
+	// single opt-in that covers new subscribers
+	if ( false === ! $status && $double_optin ) {
+		$body->status = 'subscribed';
+	} else {
+		// anyone else
+		$body->status = 'pending';
+	}
+
 	return $body;
 }
 

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -913,12 +913,8 @@ function mailchimp_sf_signup_submit() {
 		return false;
 	}
 
-	// A former subscriber is trying to resubscribe
-	// If "Update Existing Subscriber?" is enabled and the user is unsubscribed
-	// then show them the Mailchimp hosted signup form
-	if ( get_option( 'mc_update_existing' ) && 'unsubscribed' === $status ) {
-		// TODO: Make API request to fetch Mailchimp hosted sign up form and display to user
-	}
+	// TODO: If get_option( 'mc_update_existing' ) && 'unsubscribed' === $status then
+	// make an API request to fetch Mailchimp hosted sign up form and display to user
 
 	$body   = mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status, get_option( 'mc_double_optin' ) );
 	$retval = $api->post( $url, $body, 'PUT' );

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -913,6 +913,13 @@ function mailchimp_sf_signup_submit() {
 		return false;
 	}
 
+	// A former subscriber is trying to resubscribe
+	// If "Update Existing Subscriber?" is enabled and the user is unsubscribed
+	// then show them the Mailchimp hosted signup form
+	if ( get_option( 'mc_update_existing' ) && 'unsubscribed' === $status ) {
+		// TODO: Make API request to fetch Mailchimp hosted sign up form and display to user
+	}
+
 	$body   = mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status, get_option( 'mc_double_optin' ) );
 	$retval = $api->post( $url, $body, 'PUT' );
 

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -906,7 +906,7 @@ function mailchimp_sf_signup_submit() {
 
 	// If update existing is turned off and the subscriber exists, error out.
 	// TODO: Shouldn't this catch any user with any status if "Update Existing Subscriber's?" is disabled?
-	if ( get_option( 'mc_update_existing' ) === false && 'subscribed' === $status ) {
+	if ( ! get_option( 'mc_update_existing' ) && 'subscribed' === $status ) {
 		$msg   = esc_html__( 'This email address is already subscribed to the list.', 'mailchimp' );
 		$error = new WP_Error( 'mailchimp-update-existing', $msg );
 		mailchimp_sf_global_msg( '<strong class="mc_error_msg">' . $msg . '</strong>' );

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -904,10 +904,10 @@ function mailchimp_sf_signup_submit() {
 	$url    = 'lists/' . $list_id . '/members/' . md5( strtolower( $email ) );
 	$status = mailchimp_sf_check_status( $url );
 
-	// If update existing is turned off and the subscriber exists, error out.
-	// TODO: Shouldn't this catch any user with any status if "Update Existing Subscriber's?" is disabled?
-	if ( ! get_option( 'mc_update_existing' ) && 'subscribed' === $status ) {
-		$msg   = esc_html__( 'This email address is already subscribed to the list.', 'mailchimp' );
+	// If update existing is turned off and the subscriber is not new, error out.
+	$is_new_subscriber = false === $status;
+	if ( ! get_option( 'mc_update_existing' ) && ! $is_new_subscriber ) {
+		$msg   = esc_html__( 'This email address has already been subscribed to this list.', 'mailchimp' );
 		$error = new WP_Error( 'mailchimp-update-existing', $msg );
 		mailchimp_sf_global_msg( '<strong class="mc_error_msg">' . $msg . '</strong>' );
 		return false;

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -905,6 +905,7 @@ function mailchimp_sf_signup_submit() {
 	$status = mailchimp_sf_check_status( $url );
 
 	// If update existing is turned off and the subscriber exists, error out.
+	// TODO: Shouldn't this catch any user with any status if "Update Existing Subscriber's?" is disabled?
 	if ( get_option( 'mc_update_existing' ) === false && 'subscribed' === $status ) {
 		$msg   = esc_html__( 'This email address is already subscribed to the list.', 'mailchimp' );
 		$error = new WP_Error( 'mailchimp-update-existing', $msg );
@@ -964,6 +965,7 @@ function mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status
 	}
 
 	// Subscribe the user immediately unless double opt-in is enabled
+	// No need to check user $status because we're handling that before this point
 	$body->status = $double_optin ? 'pending' : 'subscribed';
 
 	return $body;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR bundles a two related issues.

- [Double Opt-In triggered despite being disabled in settings:](https://github.com/mailchimp/wordpress/issues/113) Fixes a bug causing double opt-in to occur every time regardless of Mailchimp WP settings on new user sign ups
- [Existing subscriber can sign up even if "Update Existing Subscriber?" is turned off:](https://github.com/mailchimp/wordpress/issues/114) Fixed a bug that caused the "Update Existing Subscriber?" setting to essentially always return as true. This caused the FE Mailchimp WP form to always return a success when subscribers would sign up with the same email.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #113
Closes #114 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

#### Double Opt-In triggered despite being disabled in settings
https://github.com/user-attachments/assets/c5f8d2d5-2cb9-448b-88f1-05867df832ec

1. Ensure that Double Opt-In is disabled in the Mailchimp WP settings page
2. Navigate to the FE and submit a new form submission with an email address you control (e.g. max.garceau+newsubmission@10up.com)
3. Check your email and ensure that you haven't received an email
4. Check your Mailchimp account to ensure the contact has been created

##### If Double Opt-In is enabled and a `pending` user tries to update their information, then their status will still be `pending` and they will have to confirm the original confirmation email (bug fix/logic change)
Previously, the conditional check was attempting to skip Double Opt-in for any emails with an existing status.

https://github.com/user-attachments/assets/0a49070a-afe1-482b-ac71-ba2e95fb9bac

1. Turn on Double Opt-In in the Mailchimp WP settings
2. Turn on "Update Existing Subscribers?" in the Mailchimp WP settings
3. Sign up with a new subscriber
4. DO NOT CONFIRM THE EMAIL
5. Check your Mailchimp account to confirm that the contact has not been created
6. Sign up and change some information with that same email
7. You WILL NOT receive another confirmation email. Confirm the original confirmation email.
8. Verify that the new contact is created in the Mailchimp account with the changes you've entered

#### Fix: Existing subscriber could sign up even if "Update Existing Subscriber?" is turned off

https://github.com/user-attachments/assets/8bbf31f2-a6cb-429c-b918-2cf99a49aea7

1. Turn "Update Existing Subscriber?" off in the Mailchimp WP settings
9. Sign up with a new subscriber on the FE submission form
10. Sign up a second time
11. You should receive an error stating "This email address has already been subscribed to this list"

##### If "Update Existing Subscriber?" is disabled and the email does not belong to a new subscriber then don't let them sign up (changed logic)
Previously, the conditional check would only check for `subscribed` emails to throw an error. Now, any existing email type will throw the error.

https://github.com/user-attachments/assets/b03403ed-8c40-4bf7-83b9-cd32abbdc83d

1. Turn "Update Existing Subscriber?" off in the Mailchimp WP settings
2. `subscribed` - Sign up with an already subscribed email on the FE submission form. You should see "This email address has already been subscribed to this list."
3. `unsubscribed` - Sign up with an email that has been unsubscribed from this list. You should see "This email address has already been subscribed to this list."
4. Enable Double Opt-In
12. Sign up with a new email
13. DO NOT CONFIRM THE EMAIL
14. `pending` - Try signing up again with the email. You should see "This email address has already been subscribed to this list."

Other statuses include `cleaned`, `transactional`, and `archived`, but I don't think we need to worry about testing those.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug causing all new subscribers to receive a double opt-in email.
> Fixed - Bug causing contacts with any Mailchimp status (subscribed, unsubscribed, pending, etc.) to be able to submit the sign-up form even if "Update Existing Subscriber?" was disabled.
> Fixed - Pending contacts will now still be required to confirm their original confirmation email if they try to update their contact while "Update Existing Subscribers?" and "Double Opt-in" are both enabled.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props Nathan Tetzlaff, @MaxwellGarceau, [pluckvermont](https://profiles.wordpress.org/pluckvermont/).

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
