### PR TITLE
Prevent overwriting the release content with the body text provided in the GitHub Action workflow file.

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -44,7 +44,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: ${{ steps.deploy.outputs.zip-path }}
-        body: |
-          This release contains the latest updates for the WordPress plugin.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of the Change
This PR removes the `body` parameter from the `softprops/action-gh-release@v2` GitHub Action in the Deploy to WordPress.org workflow to prevent overwriting the release content with the body text provided in the GitHub Action workflow file.  

Closes #124 

### How to test the Change
This fix can be tested when a new release happens. I have confirmed that it works by testing it on a forked repository.

### Changelog Entry
> Dev - Prevent overwriting the release content with the body text provided in the GitHub Action workflow file.

### Credits
Props @dkotter @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
