### PR TITLE
Display an error message informing the user to subscribe through the hosted form if they were previously unsubscribed.

### DIFF
--- a/lib/mailchimp/mailchimp.php
+++ b/lib/mailchimp/mailchimp.php
@@ -190,6 +190,28 @@ class MailChimp_API {
 				$merges = get_option( 'mailchimp_sf_merge_fields_' . $list_id );
 			}
 
+			// Check if the email address is in compliance state.
+			if ( ! isset( $body['errors'] ) && isset( $body['status'] ) && isset( $body['title'] ) && 400 === $body['status'] && 'Member In Compliance State' === $body['title'] ) {
+				$url     = mailchimp_sf_signup_form_url( $list_id );
+				$message = wp_kses(
+					sprintf(
+						/* translators: %s: Hosted form Url */
+						__(
+							'The email address cannot be subscribed because it was previously unsubscribed, bounced, or is under review. Please <a href="%s" target="_blank">sign up here.</a>',
+							'mailchimp'
+						),
+						esc_url( $url )
+					),
+					[
+						'a' => [
+							'href'   => [],
+							'target' => [],
+						],
+					]
+				);
+				return new WP_Error( 'mc-subscribe-error-compliance', $message );
+			}
+
 			$field_name = '';
 			foreach ( $merges as $merge ) {
 				if ( empty( $body['errors'] ) ) {

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -1224,13 +1224,16 @@ function mailchimp_sf_update_profile_url( $email ) {
 /**
  * Get signup form URL.
  *
+ * @param string $list_id List ID
  * @return string
  */
-function mailchimp_sf_signup_form_url() {
-	$dc      = get_option( 'mc_datacenter' );
-	$user    = get_option( 'mc_user' );
-	$list_id = get_option( 'mc_list_id' );
-	$url     = 'http://' . $dc . '.list-manage.com/subscribe?u=' . $user['account_id'] . '&id=' . $list_id;
+function mailchimp_sf_signup_form_url( $list_id = '' ) {
+	$dc   = get_option( 'mc_datacenter' );
+	$user = get_option( 'mc_user' );
+	if ( empty( $list_id ) ) {
+		$list_id = get_option( 'mc_list_id' );
+	}
+	$url = 'http://' . $dc . '.list-manage.com/subscribe?u=' . $user['account_id'] . '&id=' . $list_id;
 	return $url;
 }
 

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -859,9 +859,6 @@ function mailchimp_sf_signup_submit() {
 		return false;
 	}
 
-	// TODO: If get_option( 'mc_update_existing' ) && 'unsubscribed' === $status then
-	// make an API request to fetch Mailchimp hosted sign up form and display to user
-
 	$body   = mailchimp_sf_subscribe_body( $merge, $igs, $email_type, $email, $status, get_option( 'mc_double_optin' ) );
 	$retval = $api->post( $url, $body, 'PUT' );
 

--- a/tests/cypress/e2e/mailchimp-block.test.js
+++ b/tests/cypress/e2e/mailchimp-block.test.js
@@ -242,6 +242,37 @@ describe('Block Tests', () => {
 		});
 	});
 
+	it('Proper error message should display if unsubscribed user try to subscribe', () => {
+		cy.visit(`/wp-admin/post.php?post=${postId}&action=edit`);
+		cy.getBlockEditor().find('h2[aria-label="Enter a header (optional)"]').click();
+		cy.openDocumentSettingsPanel('Form Settings', 'Block');
+		cy.get('.mailchimp-double-opt-in input.components-form-toggle__input').first().uncheck();
+		cy.get('.mailchimp-update-existing-subscribers input.components-form-toggle__input')
+			.first()
+			.check();
+		cy.get('button.editor-post-publish-button').click();
+		cy.wait(500);
+
+		// Verify
+		cy.visit(`/?p=${postId}`);
+		cy.get('#mc_mv_EMAIL').should('exist');
+		cy.get('#mc_mv_EMAIL').clear().type('unsubscribed_user@gmail.com');
+		cy.get('#mc_signup_submit').should('exist');
+		cy.get('#mc_signup_submit').click();
+		cy.get('.mc_error_msg').should('exist');
+		cy.get('.mc_error_msg').contains(
+			'The email address cannot be subscribed because it was previously unsubscribed, bounced, or is under review. Please sign up here.',
+		);
+
+		// Reset
+		cy.visit(`/wp-admin/post.php?post=${postId}&action=edit`);
+		cy.getBlockEditor().find('h2[aria-label="Enter a header (optional)"]').click();
+		cy.openDocumentSettingsPanel('Form Settings', 'Block');
+		cy.get('.mailchimp-double-opt-in input.components-form-toggle__input').first().check();
+		cy.get('button.editor-post-publish-button').click();
+		cy.wait(500);
+	});
+
 	// TODO: Add tests for the Double Opt-in and Update existing subscribers settings.
 	// TODO: Add tests for the block styles settings.
 	// TODO: Add tests for the form submission.

--- a/tests/cypress/e2e/settings.test.js
+++ b/tests/cypress/e2e/settings.test.js
@@ -153,4 +153,30 @@ describe('Admin can update plugin settings', () => {
 			cy.get('#mc_unsub_link').should('not.exist');
 		});
 	});
+
+	it('Proper error message should display if unsubscribed user try to subscribe', () => {
+		cy.visit('/wp-admin/admin.php?page=mailchimp_sf_options');
+		cy.get('#mc_double_optin').uncheck();
+		cy.get('#mc_update_existing').check();
+		cy.get('input[value="Update Subscribe Form Settings"]').first().click();
+
+		// Verify
+		[shortcodePostURL, blockPostPostURL].forEach((url) => {
+			cy.visit(url);
+			cy.get('#mc_mv_EMAIL').should('exist');
+			cy.get('#mc_mv_EMAIL').clear().type('unsubscribed_user@gmail.com');
+			cy.get('#mc_signup_submit').should('exist');
+			cy.get('#mc_signup_submit').click();
+			cy.get('.mc_error_msg').should('exist');
+			cy.get('.mc_error_msg').contains(
+				'The email address cannot be subscribed because it was previously unsubscribed, bounced, or is under review. Please sign up here.',
+			);
+		});
+
+		// Reset
+		cy.visit('/wp-admin/admin.php?page=mailchimp_sf_options');
+		cy.get('#mc_double_optin').check();
+		cy.get('#mc_update_existing').check();
+		cy.get('input[value="Update Subscribe Form Settings"]').first().click();
+	});
 });

--- a/views/css/frontend.php
+++ b/views/css/frontend.php
@@ -6,7 +6,7 @@
  */
 
 ?>
-.mc_error_msg {
+.mc_error_msg, .mc_error_msg a {
 	color: red;
 	margin-bottom: 1.0em;
 }


### PR DESCRIPTION
### Description of the Change
This PR adds a new error message to inform users that they subscribe through the hosted form if they were previously unsubscribed. As mentioned in issue #117, it is not possible to re-subscribe unsubscribed users via the API. This PR ensures that an error message is displayed, instructing users to subscribe via the hosted form.

![Screenshot 2025-03-21 at 6 17 26 PM](https://github.com/user-attachments/assets/1cc8fc1e-5966-4000-aa6b-28da0e2d9cbd)

Closes #117 

### How to test the Change
1. Subscribe to the Mailchimp list.
1. Unsubscribe from the list using the link below the "Subscribe" button in the form.
1. Try to re-subscribe using the form with the same email and verify that the form displays an error message informing the user about the issue and providing a link to subscribe via the hosted form.

### Changelog Entry
> Fixed - Display an error message informing users that they must subscribe through the hosted form if they were previously unsubscribed.

### Credits
Props @MaxwellGarceau @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
