### PR TITLE
Make the form field visibility dependent on the WordPress "Include?" settings instead of the Mailchimp settings.

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -683,9 +683,15 @@ function mailchimp_sf_get_merge_vars( $list_id, $new_list ) {
 	update_option( 'mc_merge_vars', $mv['merge_fields'] );
 	foreach ( $mv['merge_fields'] as $mv_var ) {
 		$opt = 'mc_mv_' . $mv_var['tag'];
-		// turn them all on by default
 		if ( $new_list ) {
-			update_option( $opt, 'on' );
+			$public = isset( $mv_var['public'] ) ? $mv_var['public'] : false;
+			if ( ! $public ) {
+				// This is a hidden field, so we don't want to include it.
+				update_option( $opt, 'off' );
+			} else {
+				// We need to set the option to 'on' so that it shows up in the form.
+				update_option( $opt, 'on' );
+			}
 		}
 	}
 	return $mv['merge_fields'];

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -684,7 +684,7 @@ function mailchimp_sf_get_merge_vars( $list_id, $new_list ) {
 	foreach ( $mv['merge_fields'] as $mv_var ) {
 		$opt = 'mc_mv_' . $mv_var['tag'];
 		if ( $new_list ) {
-			$public = isset( $mv_var['public'] ) ? $mv_var['public'] : false;
+			$public = $mv_var['public'] ?? false;
 			if ( ! $public ) {
 				// This is a hidden field, so we don't want to include it.
 				update_option( $opt, 'off' );

--- a/mailchimp_upgrade.php
+++ b/mailchimp_upgrade.php
@@ -22,6 +22,10 @@ function mailchimp_version_check() {
 		mailchimp_update_1_6_0();
 	}
 
+	if ( false === $db_option || version_compare( '1.7.0', $db_option, '>' ) ) {
+		mailchimp_update_1_7_0();
+	}
+
 	update_option( 'mc_version', MCSF_VER );
 }
 
@@ -35,4 +39,25 @@ add_action( 'plugins_loaded', 'mailchimp_version_check' );
  */
 function mailchimp_update_1_6_0() {
 	delete_option( 'mc_rewards' );
+}
+
+/**
+ * Version 1.7.0 update routine
+ *   - Set "Include?" value to "off" for hidden fields
+ *
+ * @return void
+ */
+function mailchimp_update_1_7_0() {
+	$form_fields = get_option( 'mc_merge_vars' );
+
+	if ( ! empty( $form_fields ) && is_array( $form_fields ) ) {
+		foreach ( $form_fields as $field ) {
+			if ( ! $field['required'] && ! $field['public'] ) {
+				$option = 'mc_mv_' . $field['tag'];
+				// This is a hidden field, so we don't want to include it.
+				// We need to set the option to 'off' so that it doesn't show up in the form.
+				update_option( $option, 'off' );
+			}
+		}
+	}
 }

--- a/mailchimp_widget.php
+++ b/mailchimp_widget.php
@@ -204,11 +204,7 @@ function mailchimp_sf_signup_form( $args = array() ) {
 
 		// Loop over our vars, and output the ones that are set to display
 		foreach ( $mv as $mv_var ) {
-			if ( ! $mv_var['public'] ) {
-				echo '<div style="display:none;">' . mailchimp_form_field( $mv_var, $num_fields ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ignoring because form field is escaped in function
-			} else {
-				echo mailchimp_form_field( $mv_var, $num_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ignoring because form field is escaped in function
-			}
+			echo mailchimp_form_field( $mv_var, $num_fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ignoring because form field is escaped in function
 		}
 
 		// Show an explanation of the * if there's more than one field

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@wordpress/server-side-render": "^5.2.0"
       },
       "devDependencies": {
-        "@10up/cypress-wp-utils": "^0.4.0",
+        "@10up/cypress-wp-utils": "^0.5.0",
         "@wordpress/env": "^10.2.0",
         "10up-toolkit": "^6.2.0",
         "cypress": "^13.13.2",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.4.0.tgz",
-      "integrity": "sha512-7cNELIX6ml5V9JEU83iEyQ6dkZ77ImdR5HKjUP4oyArQogPVcFPUnokU7GInH8DicqXbESrrkxZ0IfnNtNWh+A==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.5.0.tgz",
+      "integrity": "sha512-i6Z1CtW8qyw2qGN393jb2tcAT62cwmh7W0Yps3lwpHC/1c1b5LbnwyuAg/WNz5X7eIY5mL8Xq/a8u17T73Lsbw==",
       "dev": true,
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "10up-toolkit build"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "^0.4.0",
+    "@10up/cypress-wp-utils": "^0.5.0",
     "@wordpress/env": "^10.2.0",
     "10up-toolkit": "^6.2.0",
     "cypress": "^13.13.2",

--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -302,7 +302,7 @@ $is_list_selected = false;
 								<td><?php echo esc_html( ( 1 === intval( $mv_var['required'] ) ) ? 'Y' : 'N' ); ?></td>
 								<td>
 									<?php
-									if ( ! $mv_var['required'] && $mv_var['public'] ) {
+									if ( ! $mv_var['required'] ) {
 										$opt = 'mc_mv_' . $mv_var['tag'];
 										?>
 										<label class="screen-reader-text" for="<?php echo esc_attr( $opt ); ?>">


### PR DESCRIPTION
### Description of the Change
This PR updates the existing behavior of how form fields are displayed on the form. Currently, form fields are shown based on a combination of settings from both Mailchimp and WordPress. If a form field is marked as hidden in Mailchimp, it does not appear on the form, while a visible field can be included in the form based on the settings on the WordPress side.

This PR updates this behavior so that form field visibility is determined solely by the **"Include?"** option in the WordPress settings, regardless of the Mailchimp settings.

When a new list is set up, hidden fields in Mailchimp will have their **"Include?"** setting turned off (hidden) by default. Additionally, this PR includes an upgrade script to ensure that forms with hidden fields based on Mailchimp settings do not accidentally start displaying after the update.

Closes #34

### How to test the Change
1. Mark a few form fields as hidden in Mailchimp.  
2. Go to the **Mailchimp settings** page in wp-admin, log in to your Mailchimp account, and select an audience list.  
3. Verify that hidden fields have their **"Include?"** setting turned off (checkbox unchecked) by default.  
4. Enable the **"Include?"** option for hidden fields and save the settings.  
5. Go to the front end and verify that the form field is now visible.  
6. Submit the form with values and confirm that:  
   - The form submits successfully.  
   - The submitted details are correctly reflected in the Mailchimp contact.
   
#### Backward Compatibility  
1. For existing users on the `trunk` branch:  
   - Set up the plugin and form.  
   - Verify that form fields are hidden based on Mailchimp settings.  
2. Update to this PR branch and change the plugin version to **1.7.0** in [`mailchimp.php`](https://github.com/mailchimp/wordpress/blob/develop/mailchimp.php#L68) by replacing the line with:  
   ```php
   define( 'MCSF_VER', '1.7.0' );
   ```  
3. Visit the settings page and ensure that all hidden fields have **"Include?"** turned off and are not visible on the front end.  

### Changelog Entry
> Changed - Make the form field visibility dependent on the WordPress "Include?" settings instead of the Mailchimp settings.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @qasumitbagthariya @dkotter @jeffpaul @MaxwellGarceau @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
