### PR TITLE
Add a note to set the website URL in the Mailchimp Audience settings.

### DIFF
--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -241,6 +241,26 @@ $is_list_selected = false;
 							<em><label for="mc_use_unsub_link"><?php esc_html_e( 'We\'ll automatically  add a link to your list\'s unsubscribe form.', 'mailchimp' ); ?></label></em>
 						</td>
 					</tr>
+					<tr valign="top">
+						<td colspan="2">
+						<?php
+						echo wp_kses(
+							sprintf(
+								/* translators: %s: link to Mailchimp */
+								__( '<strong>Note:</strong> If you haven\'t already, please <a href="%s" target="_blank">update</a> your website URL in the Mailchimp Audience settings to let users to return to your site.', 'mailchimp' ),
+								esc_url( 'https://mailchimp.com/help/change-or-update-the-return-to-our-website-button/' )
+							),
+							[
+								'a' => [
+									'href'   => [],
+									'target' => [],
+								],
+								'strong' => [],
+							]
+						)
+						?>
+						</td>
+					</tr>
 				</table>
 				<input type="submit" value="<?php esc_attr_e( 'Update Subscribe Form Settings', 'mailchimp' ); ?>" class="button mailchimp-sf-button small mc-submit" /><br/>
 			</div>


### PR DESCRIPTION
### Description of the Change
As reported in #91 and #92, the "« return to our website" button could lead to a 404 error from the subscribe/unsubscribe confirmation page if the website URL is not set in the Mailchimp Audience settings.

This PR adds a note under the "List Options" section, instructing users to set the website URL in the Mailchimp Audience settings to prevent 404 errors and ensure users can return to the website without any issues.

Closes #91
Closes #92

### How to test the Change
- Verify that the note is shown under the "List Options" section of the settings.

### Changelog Entry
> Added - A note advising users to set the website URL in the Mailchimp Audience settings.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MaxwellGarceau @dkotter @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
