### PR TITLE
Add a confirmation prompt before logging out the user.

### DIFF
--- a/tests/cypress/e2e/logout.test.js
+++ b/tests/cypress/e2e/logout.test.js
@@ -7,6 +7,12 @@ describe('Logout tests', () => {
 	it('Admin can logout', () => {
 		cy.visit('/wp-admin/admin.php?page=mailchimp_sf_options');
 		cy.get('#mailchimp_sf_oauth_connect').should('not.exist');
+
+		cy.on('window:confirm', (text) => {
+			expect(text).to.contains('Are you sure you want to log out?');
+			return true;
+		});
+
 		cy.get('input[value="Logout"]').click();
 
 		// connect to "Mailchimp" Account button should be visible.

--- a/views/setup_page.php
+++ b/views/setup_page.php
@@ -21,7 +21,7 @@ $is_list_selected = false;
 			<td><h3><?php esc_html_e( 'Logged in as', 'mailchimp' ); ?>: <?php echo esc_html( $user['username'] ); ?></h3>
 			</td>
 			<td>
-				<form method="post" action="">
+				<form method="post" action="" onsubmit="return confirm('<?php echo esc_js( __( 'Are you sure you want to log out?', 'mailchimp' ) ); ?>');">
 					<input type="hidden" name="mcsf_action" value="logout"/>
 					<input type="submit" name="Submit" value="<?php esc_attr_e( 'Logout', 'mailchimp' ); ?>" class="button button-secondary mailchimp-sf-button small" />
 					<?php wp_nonce_field( 'mc_logout', '_mcsf_nonce_action' ); ?>


### PR DESCRIPTION
### Description of the Change
As reported in #147, currently we do not ask for confirmation before logging out the user. This PR introduces a minor improvement by adding a confirmation prompt before the user is logged out.

Closes #147 

### How to test the Change
1. Log in with your Mailchimp account on the plugin settings page.
1. Click **Logout** and verify that a confirmation prompt appears before logging out.

### Changelog Entry
> Added - Confirmation prompt before logging out the user.

### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
