### PR TITLE
Enhancement/paginate lists

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1070,6 +1070,38 @@ a.mailchimp-sf-button.mailchimp-cancel-user-sync-button:hover {
 	margin-bottom: 16px;
 }
 
+/* List Pagination */
+.mailchimp-sf-list-pagination {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 12px;
+	margin-top: 8px;
+	margin-bottom: 16px;
+}
+
+.mailchimp-sf-list-pagination .button {
+	border-color: var(--mailchimp-color-link);
+	color: var(--mailchimp-color-link);
+	font-size: 13px;
+	line-height: 2;
+	height: 30px;
+	padding: 0 10px;
+	text-decoration: none;
+}
+
+.mailchimp-sf-list-pagination .button:hover,
+.mailchimp-sf-list-pagination .button:focus {
+	border-color: var(--mailchimp-color-link-hover);
+	color: var(--mailchimp-color-link-hover);
+	background-color: #f6f7f7;
+}
+
+.mailchimp-sf-list-pagination-info {
+	font-size: 13px;
+	color: var(--mailchimp-color-text-gray);
+}
+
 /* Buttons */
 .mailchimp-sf-button,
 .button.mailchimp-sf-button {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1065,9 +1065,14 @@ a.mailchimp-sf-button.mailchimp-cancel-user-sync-button:hover {
 .mailchimp-sf-settings-list-select-wrapper {
 	display: flex;
 	flex-direction: row;
-	align-items: center;
+	align-items: flex-start;
 	gap: 8px;
 	margin-bottom: 16px;
+}
+
+.mailchimp-sf-settings-list-select {
+	display: flex;
+	flex-direction: column;
 }
 
 /* List Pagination */
@@ -1075,9 +1080,17 @@ a.mailchimp-sf-button.mailchimp-cancel-user-sync-button:hover {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: 12px;
+	justify-content: space-between;
 	margin-top: 8px;
-	margin-bottom: 16px;
+}
+
+.mailchimp-sf-pagination-prev,
+.mailchimp-sf-pagination-next {
+	flex: 1;
+}
+
+.mailchimp-sf-pagination-next {
+	text-align: right;
 }
 
 .mailchimp-sf-list-pagination .button {

--- a/includes/admin/templates/settings.php
+++ b/includes/admin/templates/settings.php
@@ -95,6 +95,40 @@ $is_list_selected = false;
 											}
 											?>
 										</select>
+										<?php
+										if ( $total_items > MCSF_LISTS_PER_PAGE ) {
+											$base_url   = admin_url( 'admin.php?page=mailchimp_sf_options' );
+											$has_prev   = $mc_list_page > 0;
+											$has_next   = ( $mc_list_offset + count( $lists ) ) < $total_items;
+											$first_item = $mc_list_offset + 1;
+											$last_item  = $mc_list_offset + count( $lists );
+											?>
+											<div class="mailchimp-sf-list-pagination">
+												<div class="mailchimp-sf-pagination-prev">
+													<?php if ( $has_prev ) : ?>
+														<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page - 1, $base_url ) ); ?>" class="button">&laquo; <?php esc_html_e( 'Previous', 'mailchimp' ); ?></a>
+													<?php endif; ?>
+												</div>
+												<span class="mailchimp-sf-list-pagination-info">
+													<?php
+													printf(
+														/* translators: 1: first item number, 2: last item number, 3: total items */
+														esc_html__( '%1$d&ndash;%2$d of %3$d lists', 'mailchimp' ),
+														$first_item,
+														$last_item,
+														$total_items
+													);
+													?>
+												</span>
+												<div class="mailchimp-sf-pagination-next">
+													<?php if ( $has_next ) : ?>
+														<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page + 1, $base_url ) ); ?>" class="button"><?php esc_html_e( 'Next', 'mailchimp' ); ?> &raquo;</a>
+													<?php endif; ?>
+												</div>
+											</div>
+											<?php
+										}
+										?>
 									</div>
 									<div class="mailchimp-sf-settings-list-select-button">
 										<input type="hidden" name="mcsf_action" value="update_mc_list_id" />
@@ -103,34 +137,6 @@ $is_list_selected = false;
 									</div>
 								</div>
 								<?php
-								if ( $total_items > MCSF_LISTS_PER_PAGE ) {
-									$base_url   = admin_url( 'admin.php?page=mailchimp_sf_options' );
-									$has_prev   = $mc_list_page > 0;
-									$has_next   = ( $mc_list_offset + count( $lists ) ) < $total_items;
-									$first_item = $mc_list_offset + 1;
-									$last_item  = $mc_list_offset + count( $lists );
-									?>
-									<div class="mailchimp-sf-list-pagination">
-										<?php if ( $has_prev ) : ?>
-											<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page - 1, $base_url ) ); ?>" class="button">&laquo; <?php esc_html_e( 'Previous', 'mailchimp' ); ?></a>
-										<?php endif; ?>
-										<span class="mailchimp-sf-list-pagination-info">
-											<?php
-											printf(
-												/* translators: 1: first item number, 2: last item number, 3: total items */
-												esc_html__( '%1$d&ndash;%2$d of %3$d lists', 'mailchimp' ),
-												$first_item,
-												$last_item,
-												$total_items
-											);
-											?>
-										</span>
-										<?php if ( $has_next ) : ?>
-											<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page + 1, $base_url ) ); ?>" class="button"><?php esc_html_e( 'Next', 'mailchimp' ); ?> &raquo;</a>
-										<?php endif; ?>
-									</div>
-									<?php
-								}
 							} //end select list
 							?>
 						</form>

--- a/includes/admin/templates/settings.php
+++ b/includes/admin/templates/settings.php
@@ -49,10 +49,13 @@ $is_list_selected = false;
 						<p class="mailchimp-sf-settings-list-description">
 							<strong><?php esc_html_e( 'Note:', 'mailchimp' ); ?></strong> <?php esc_html_e( 'List settings are fetched from Mailchimp, fetching a new list will override your current settings.', 'mailchimp' ); ?>
 						</p>
+						<?php
+						$mc_list_page   = isset( $_GET['mc_list_page'] ) ? max( 0, intval( $_GET['mc_list_page'] ) ) : 0;
+						$mc_list_offset = $mc_list_page * MCSF_LISTS_PER_PAGE;
+						?>
 						<form method="post" action="<?php echo esc_url( add_query_arg( array( 'page' => 'mailchimp_sf_options' ), admin_url( 'admin.php' ) ) ); ?>">
 							<?php
-							// we *could* support paging, but few users have that many lists (and shouldn't)
-							$lists = $api->get( 'lists', 100, array( 'fields' => 'lists.id,lists.name' ) );
+							$lists = $api->get( 'lists', MCSF_LISTS_PER_PAGE, array( 'fields' => 'lists.id,lists.name,total_items' ), $mc_list_offset );
 							if ( is_wp_error( $lists ) ) {
 								$msg = sprintf(
 									/* translators: %s: error message */
@@ -68,6 +71,7 @@ $is_list_selected = false;
 								);
 								admin_notice_error( $msg );
 							} else {
+								$total_items      = $lists['total_items'] ?? 0;
 								$lists            = $lists['lists'];
 								$option           = get_option( 'mc_list_id' );
 								$list_ids         = array_map(
@@ -76,7 +80,7 @@ $is_list_selected = false;
 									},
 									$lists
 								);
-								$is_list_selected = in_array( $option, $list_ids, true );
+								$is_list_selected = ! empty( $option );
 								?>
 								<div class="mailchimp-sf-settings-list-select-wrapper">
 									<div class="mailchimp-sf-settings-list-select">
@@ -99,6 +103,34 @@ $is_list_selected = false;
 									</div>
 								</div>
 								<?php
+								if ( $total_items > MCSF_LISTS_PER_PAGE ) {
+									$base_url   = admin_url( 'admin.php?page=mailchimp_sf_options' );
+									$has_prev   = $mc_list_page > 0;
+									$has_next   = ( $mc_list_offset + count( $lists ) ) < $total_items;
+									$first_item = $mc_list_offset + 1;
+									$last_item  = $mc_list_offset + count( $lists );
+									?>
+									<div class="mailchimp-sf-list-pagination">
+										<?php if ( $has_prev ) : ?>
+											<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page - 1, $base_url ) ); ?>" class="button">&laquo; <?php esc_html_e( 'Previous', 'mailchimp' ); ?></a>
+										<?php endif; ?>
+										<span class="mailchimp-sf-list-pagination-info">
+											<?php
+											printf(
+												/* translators: 1: first item number, 2: last item number, 3: total items */
+												esc_html__( '%1$d&ndash;%2$d of %3$d lists', 'mailchimp' ),
+												$first_item,
+												$last_item,
+												$total_items
+											);
+											?>
+										</span>
+										<?php if ( $has_next ) : ?>
+											<a href="<?php echo esc_url( add_query_arg( 'mc_list_page', $mc_list_page + 1, $base_url ) ); ?>" class="button"><?php esc_html_e( 'Next', 'mailchimp' ); ?> &raquo;</a>
+										<?php endif; ?>
+									</div>
+									<?php
+								}
 							} //end select list
 							?>
 						</form>

--- a/includes/blocks/class-mailchimp-list-subscribe-form-blocks.php
+++ b/includes/blocks/class-mailchimp-list-subscribe-form-blocks.php
@@ -80,6 +80,7 @@ class Mailchimp_List_Subscribe_Form_Blocks {
 			'interest_groups_visibility'  => $interest_groups_visibility,
 			'merge_fields'                => $merge_fields,
 			'interest_groups'             => $interest_groups,
+			'lists_per_page'              => MCSF_LISTS_PER_PAGE,
 		);
 		$data = 'window.mailchimp_sf_block_data = ' . wp_json_encode( $data );
 		wp_add_inline_script( 'mailchimp-mailchimp-editor-script', $data, 'before' );
@@ -109,13 +110,23 @@ class Mailchimp_List_Subscribe_Form_Blocks {
 			return array();
 		}
 
-		// we *could* support paging, but 100 is more than enough for now.
-		$lists = $api->get( 'lists', 100, array( 'fields' => 'lists.id,lists.name,lists.email_type_option' ) );
-		if ( is_wp_error( $lists ) ) {
-			return array();
-		}
+		// Fetch all lists using paginated API requests.
+		$all_lists   = array();
+		$offset      = 0;
+		$total_items = null;
+		do {
+			$response = $api->get( 'lists', MCSF_LISTS_API_FETCH_LIMIT, array( 'fields' => 'lists.id,lists.name,lists.email_type_option,total_items' ), $offset );
+			if ( is_wp_error( $response ) ) {
+				return array();
+			}
+			if ( null === $total_items ) {
+				$total_items = $response['total_items'] ?? 0;
+			}
+			$all_lists = array_merge( $all_lists, $response['lists'] ?? array() );
+			$offset   += MCSF_LISTS_API_FETCH_LIMIT;
+		} while ( count( $all_lists ) < $total_items );
 
-		$lists = $lists['lists'] ?? array();
+		$lists = $all_lists;
 
 		// Update the option with the lists.
 		update_option( 'mailchimp_sf_lists', $lists );

--- a/includes/blocks/mailchimp/edit.js
+++ b/includes/blocks/mailchimp/edit.js
@@ -12,6 +12,9 @@ import {
 	SelectControl,
 	Spinner,
 	Placeholder,
+	Button,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -66,6 +69,12 @@ export const BlockEdit = (props) => {
 	const [listData, setListData] = useState({});
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState('');
+	const [listPage, setListPage] = useState(0);
+
+	const listsPerPage = window.mailchimp_sf_block_data?.lists_per_page || 50;
+	const totalLists = lists?.length || 0;
+	const totalPages = Math.ceil(totalLists / listsPerPage);
+	const pagedLists = lists?.slice(listPage * listsPerPage, (listPage + 1) * listsPerPage) || [];
 	const blockProps = useBlockProps();
 	const { replaceInnerBlocks } = useDispatch(blockEditorStore);
 
@@ -93,7 +102,7 @@ export const BlockEdit = (props) => {
 	}
 
 	listOptions.push(
-		...(lists?.map((list) => ({
+		...(pagedLists?.map((list) => ({
 			label: list.name,
 			value: list.id,
 		})) || []),
@@ -416,6 +425,35 @@ export const BlockEdit = (props) => {
 						)}
 						__nextHasNoMarginBottom
 					/>
+					{totalPages > 1 && (
+						<Flex justify="space-between" align="center" style={{ marginTop: '8px' }}>
+							<FlexItem>
+								<Button
+									variant="tertiary"
+									disabled={listPage === 0}
+									onClick={() => setListPage((p) => p - 1)}
+								>
+									&laquo; {__('Prev', 'mailchimp')}
+								</Button>
+							</FlexItem>
+							<FlexItem>
+								<span style={{ fontSize: '12px' }}>
+									{listPage * listsPerPage + 1}&ndash;
+									{Math.min((listPage + 1) * listsPerPage, totalLists)}{' '}
+									{sprintf(__('of %d', 'mailchimp'), totalLists)}
+								</span>
+							</FlexItem>
+							<FlexItem>
+								<Button
+									variant="tertiary"
+									disabled={listPage >= totalPages - 1}
+									onClick={() => setListPage((p) => p + 1)}
+								>
+									{__('Next', 'mailchimp')} &raquo;
+								</Button>
+							</FlexItem>
+						</Flex>
+					)}
 				</PanelBody>
 				<PanelBody title={__('Form Settings', 'mailchimp')} initialOpen={false}>
 					<ToggleControl

--- a/includes/class-mailchimp-admin.php
+++ b/includes/class-mailchimp-admin.php
@@ -372,9 +372,23 @@ class Mailchimp_Admin {
 			update_option( 'mc_user', $this->sanitize_data( $user ) );
 
 			// Clear Mailchimp List ID if saved list is not available.
-			$lists = $api->get( 'lists', 100, array( 'fields' => 'lists.id,lists.name,lists.email_type_option' ) );
-			if ( ! is_wp_error( $lists ) ) {
-				$lists         = $lists['lists'] ?? array();
+			$all_lists   = array();
+			$offset      = 0;
+			$total_items = null;
+			do {
+				$response = $api->get( 'lists', MCSF_LISTS_API_FETCH_LIMIT, array( 'fields' => 'lists.id,lists.name,lists.email_type_option,total_items' ), $offset );
+				if ( is_wp_error( $response ) ) {
+					break;
+				}
+				if ( null === $total_items ) {
+					$total_items = $response['total_items'] ?? 0;
+				}
+				$all_lists = array_merge( $all_lists, $response['lists'] ?? array() );
+				$offset   += MCSF_LISTS_API_FETCH_LIMIT;
+			} while ( count( $all_lists ) < $total_items );
+
+			$lists = $all_lists;
+			if ( ! empty( $lists ) ) {
 				$saved_list_id = get_option( 'mc_list_id' );
 				$list_ids      = array_map(
 					function ( $ele ) {

--- a/lib/mailchimp/mailchimp.php
+++ b/lib/mailchimp/mailchimp.php
@@ -78,15 +78,20 @@ class MailChimp_API {
 	 * @param string  $endpoint The Mailchimp endpoint.
 	 * @param integer $count The count to retrieve.
 	 * @param array   $fields The fields to retrieve.
+	 * @param integer $offset The offset for pagination.
 	 * @return mixed
 	 */
-	public function get( $endpoint, $count = 10, $fields = array() ) {
+	public function get( $endpoint, $count = 10, $fields = array(), $offset = 0 ) {
 		$query_params = '';
 
 		$url = $this->api_url . $endpoint;
 
 		if ( $count ) {
 			$query_params = 'count=' . $count . '&';
+		}
+
+		if ( $offset ) {
+			$query_params .= 'offset=' . $offset . '&';
 		}
 
 		if ( ! empty( $fields ) ) {

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -555,14 +555,22 @@ function mailchimp_sf_change_list_if_necessary() {
 	$api = mailchimp_sf_get_api();
 	if ( ! $api ) { return; }
 
-	// we *could* support paging, but few users have that many lists (and shouldn't)
-	$lists = $api->get( 'lists', 100, array( 'fields' => 'lists.id,lists.name,lists.email_type_option' ) );
+	$all_lists   = array();
+	$offset      = 0;
+	$total_items = null;
+	do {
+		$response = $api->get( 'lists', MCSF_LISTS_API_FETCH_LIMIT, array( 'fields' => 'lists.id,lists.name,lists.email_type_option,total_items' ), $offset );
+		if ( ! isset( $response['lists'] ) || is_wp_error( $response ) ) {
+			return;
+		}
+		if ( null === $total_items ) {
+			$total_items = $response['total_items'] ?? 0;
+		}
+		$all_lists = array_merge( $all_lists, $response['lists'] );
+		$offset   += MCSF_LISTS_API_FETCH_LIMIT;
+	} while ( count( $all_lists ) < $total_items );
 
-	if ( ! isset( $lists['lists'] ) || is_wp_error( $lists['lists'] ) ) {
-		return;
-	}
-
-	$lists = $lists['lists'];
+	$lists = $all_lists;
 
 	if ( is_array( $lists ) && ! empty( $lists ) ) {
 

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -72,6 +72,12 @@ define( 'MCSF_VER', '2.0.1' );
 // What's our permission (capability) threshold
 define( 'MCSF_CAP_THRESHOLD', 'manage_options' );
 
+// Number of lists to fetch per API request when paginating
+define( 'MCSF_LISTS_API_FETCH_LIMIT', 100 );
+
+// Number of lists to display per page in the admin UI and block editor
+define( 'MCSF_LISTS_PER_PAGE', 50 );
+
 // Define our location constants, both MCSF_DIR and MCSF_URL
 mailchimp_sf_where_am_i();
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Prior to this PR, accounts with >100 lists were hard-capped — only 100 lists were fetched via the API and only 100 appeared in the dropdown in the admin UI

Now the dropdowns in the admin UI and the block editor display 50 lists at a time with prev/next controls to fetch and display additional lists (number displayed is controlled by MCSF_LISTS_PER_PAGE)
[Actually the Mailchimp block has to fetch all lists up-front but mimics the admin UI with pagination across dropdowns of 50 lists]

The API get() method now accepts an $offset parameter enabling fetching lists in blocks

When the plugin needs to fetch ALL lists, it issues multiple API calls in batches of 100 (controlled by MCSF_LISTS_API_FETCH_LIMIT)

Admin list section UI:
<img width="522" height="307" alt="image" src="https://github.com/user-attachments/assets/7ae8bc74-4a79-443f-859e-13bbebd0961b" />

Mailchimp Block list selection UI:
<img width="336" height="335" alt="image" src="https://github.com/user-attachments/assets/8ff73693-23da-4210-806c-1478b46503c9" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #186 - "Plugin limited to 100 lists"

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Connect plugin to a Mailchimp account with >100 lists

**Mailchimp form:**
2. Navigate to the site's admin page at /wp-admin/admin.php?page=mailchimp_sf_options
3. Observe only 50 lists shown in list selection dropdown and text underneath reads "1-50 of xxx lists"
4. Click next/prev buttons as appropriate and observe status text changes and contents of dropdown list changes

**Block editor:**
5. Create a page
6. Add a Mailchimp block
7. Observe "select a list" dropdown in block settings contains only 50 lists
8. Functionality and navigation duplicates the Mailchimp form UI


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Enhancement/paginate lists


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jonjennings

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
