### PR TITLE
Bump WordPress Tested up to version 7.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1449,6 +1449,7 @@ input[type=radio].mailchimp-sf-radio {
 
 input[type=radio].mailchimp-sf-radio:checked {
 	border: 2px solid var(--mailchimp-color-link);
+	background-color: #fff;
 }
 
 input[type=radio].mailchimp-sf-radio:checked:before {

--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -17,7 +17,7 @@ namespace Mailchimp\WordPress\Includes\Admin;
  * @param string $msg The message to display.
  * @return void
  */
-function admin_notice_success( string $msg ): void {
+function admin_notice_success( string $msg ) {
 	\Mailchimp_Admin_Notices::instance()->add( $msg, 'success' );
 }
 
@@ -31,6 +31,6 @@ function admin_notice_success( string $msg ): void {
  * @param string $msg The message to display.
  * @return void
  */
-function admin_notice_error( string $msg ): void {
+function admin_notice_error( string $msg ) {
 	\Mailchimp_Admin_Notices::instance()->add( $msg, 'error' );
 }

--- a/includes/admin/admin-notices.php
+++ b/includes/admin/admin-notices.php
@@ -9,73 +9,28 @@ namespace Mailchimp\WordPress\Includes\Admin;
 
 /**
  * Display success admin notice.
- *
- * NOTE: WordPress localization i18n functionality should be done
- * on string literals outside of this function in order to work
- * correctly.
- *
- * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ * This function is now a wrapper around the Mailchimp_Admin_Notices class, will be deprecated in future versions. Use that class instead.
  *
  * @since 1.7.0
+ * @since x.x.x - Moved notice rendering to class-mailchimp-admin-notices.php
+ *
  * @param string $msg The message to display.
  * @return void
  */
-function admin_notice_success( string $msg ) {
-	?>
-	<div class="notice notice-success is-dismissible">
-		<p>
-		<?php
-		echo wp_kses(
-			$msg,
-			array(
-				'a'      => array(
-					'href'   => array(),
-					'title'  => array(),
-					'target' => array(),
-				),
-				'strong' => array(),
-				'em'     => array(),
-				'br'     => array(),
-			)
-		);
-		?>
-		</p>
-	</div>
-	<?php
+function admin_notice_success( string $msg ): void {
+	\Mailchimp_Admin_Notices::instance()->add( $msg, 'success' );
 }
 
 /**
  * Display error admin notice.
- *
- * NOTE: WordPress localization i18n functionality should be done
- * on string literals outside of this function in order to work
- * correctly.
- *
- * For more info read here: https://salferrarello.com/why-__-needs-a-hardcoded-string-in-wordpress/
+ * This function is now a wrapper around the Mailchimp_Admin_Notices class, will be deprecated in future versions. Use that class instead.
  *
  * @since 1.7.0
+ * @since x.x.x - Moved notice rendering to class-mailchimp-admin-notices.php
+ *
  * @param string $msg The message to display.
  * @return void
  */
-function admin_notice_error( string $msg ) {
-	?>
-	<div class="notice notice-error">
-		<p>
-		<?php
-		echo wp_kses(
-			$msg,
-			array(
-				'a'      => array(
-					'href'   => array(),
-					'title'  => array(),
-					'target' => array(),
-				),
-				'strong' => array(),
-				'em'     => array(),
-			)
-		);
-		?>
-		</p>
-	</div>
-	<?php
+function admin_notice_error( string $msg ): void {
+	\Mailchimp_Admin_Notices::instance()->add( $msg, 'error' );
 }

--- a/includes/admin/class-mailchimp-admin-notices.php
+++ b/includes/admin/class-mailchimp-admin-notices.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Mailchimp admin notices class.
+ *
+ * Registers notices and renders them on the admin_notices hook in the same request.
+ *
+ * @since x.x.x
+ *
+ * @package Mailchimp
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Mailchimp_Admin_Notices
+ *
+ * @since x.x.x
+ */
+class Mailchimp_Admin_Notices {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Mailchimp_Admin_Notices|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Queued notices for the current request.
+	 *
+	 * @var array<int, array{message: string, type: string}>
+	 */
+	private $notices = array();
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Mailchimp_Admin_Notices
+	 */
+	public static function instance(): Mailchimp_Admin_Notices {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register the admin_notices hook.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_action( 'admin_notices', array( $this, 'render' ) );
+	}
+
+	/**
+	 * Queue an admin notice.
+	 *
+	 * @param string $message Notice message (already escaped/translated by caller).
+	 * @param string $type    Notice type: success or error.
+	 * @return void
+	 */
+	public function add( string $message, string $type ): void {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( did_action( 'admin_notices' ) ) {
+			$this->print_notice( $message, $type );
+			return;
+		}
+
+		$this->notices[] = array(
+			'message' => $message,
+			'type'    => $type,
+		);
+	}
+
+	/**
+	 * Render all queued notices.
+	 *
+	 * @return void
+	 */
+	public function render(): void {
+		foreach ( $this->notices as $notice ) {
+			$this->print_notice( $notice['message'], $notice['type'] );
+		}
+
+		$this->notices = array();
+	}
+
+	/**
+	 * Print a single admin notice.
+	 *
+	 * @param string $message Notice message.
+	 * @param string $type    Notice type: success or error.
+	 * @return void
+	 */
+	private function print_notice( string $message, string $type ): void {
+		$classes = array( 'notice', 'notice-' . sanitize_html_class( $type ) );
+
+		if ( 'success' === $type ) {
+			$classes[] = 'is-dismissible';
+		}
+
+		$allowed_html = array(
+			'a'      => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'strong' => array(),
+			'em'     => array(),
+			'br'     => array(),
+		);
+
+		?>
+		<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+			<p>
+				<?php echo wp_kses( $message, $allowed_html ); ?>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/includes/admin/class-mailchimp-admin-notices.php
+++ b/includes/admin/class-mailchimp-admin-notices.php
@@ -53,7 +53,7 @@ class Mailchimp_Admin_Notices {
 	 *
 	 * @return void
 	 */
-	public function init(): void {
+	public function init() {
 		add_action( 'admin_notices', array( $this, 'render' ) );
 	}
 
@@ -64,7 +64,7 @@ class Mailchimp_Admin_Notices {
 	 * @param string $type    Notice type: success or error.
 	 * @return void
 	 */
-	public function add( string $message, string $type ): void {
+	public function add( string $message, string $type ) {
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -85,7 +85,7 @@ class Mailchimp_Admin_Notices {
 	 *
 	 * @return void
 	 */
-	public function render(): void {
+	public function render() {
 		foreach ( $this->notices as $notice ) {
 			$this->print_notice( $notice['message'], $notice['type'] );
 		}
@@ -100,7 +100,7 @@ class Mailchimp_Admin_Notices {
 	 * @param string $type    Notice type: success or error.
 	 * @return void
 	 */
-	private function print_notice( string $message, string $type ): void {
+	private function print_notice( string $message, string $type ) {
 		$classes = array( 'notice', 'notice-' . sanitize_html_class( $type ) );
 
 		if ( 'success' === $type ) {

--- a/includes/class-mailchimp-admin.php
+++ b/includes/class-mailchimp-admin.php
@@ -48,6 +48,8 @@ class Mailchimp_Admin {
 		add_action( 'admin_menu', array( $this, 'add_admin_menu_pages' ) );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ) );
 
+		Mailchimp_Admin_Notices::instance()->init();
+
 		$user_sync = new Mailchimp_User_Sync();
 		$user_sync->init();
 	}

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -96,6 +96,7 @@ require_once 'mailchimp_upgrade.php';
 // Init Admin functions.
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-mailchimp-user-sync-backgroud-process.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/admin/class-mailchimp-user-sync.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/admin/class-mailchimp-admin-notices.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-mailchimp-admin.php';
 $admin = new Mailchimp_Admin();
 $admin->init();

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -5,7 +5,7 @@
  * Description:       Add a Mailchimp signup form block, widget or shortcode to your WordPress site.
  * Text Domain:       mailchimp
  * Version:           2.0.1
- * Requires at least: 6.4
+ * Requires at least: 6.6
  * Requires PHP:      7.0
  * PHP tested up to:  8.3
  * Author:            Mailchimp

--- a/phpcs-compat.xml
+++ b/phpcs-compat.xml
@@ -12,6 +12,6 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 	<config name="testVersion" value="7.0-"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 
 	<exclude-pattern>*/tests/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 	<config name="testVersion" value="7.0-"/>
 
 	<!-- Exclude the PHPCompatibilityWP ruleset -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Mailchimp List Subscribe Form ===
 Contributors: Mailchimp
 Tags:         mailchimp, email, newsletter, signup, marketing
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag:   2.0.1
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -16,6 +16,18 @@
 import '@10up/cypress-wp-utils';
 import './commands';
 
+Cypress.on('uncaught:exception', (err, runnable) => {
+	/*
+	 * Noticed this "Transition was skipped" error on WP 7.0
+	 */
+	if (err.message.includes('Transition was skipped')) {
+		// returning false here prevents Cypress from failing the test
+		return false;
+	}
+
+	return runnable;
+});
+
 // TODO: Initialize tests from a blank state
 // TODO: Wipe WP data related to a users options
 // TODO: Delete all contacts in a users Mailchimp account


### PR DESCRIPTION
### Description of the Change
PR bumps WordPress "tested up to" version 7.0 and bump WordPress minimum supported version to 6.6.

There are few UI issue reported as part of manual testing, those issue are also addressed.

**Admin Notices Refactor:**
- Introduced a new `Mailchimp_Admin_Notices` class to handle admin notices as a singleton, queuing and rendering notices in a standardized way.
- Refactored legacy `admin_notice_success` and `admin_notice_error` functions to delegate to the new class, marking them as wrappers and preparing them for deprecation. (Haven't used new class everywhere yet to avoid major refactoring in this compact PR)

**WordPress Version Updates:**
- Updated the minimum required WordPress version to 6.6 in plugin headers, test workflows, and code style config files.
- Updated the "Tested up to" version in `readme.txt` to 7.0.


**Minor UI Fix:**
- Ensured checked radio buttons in the admin UI have a white background for better visibility.

Closes #202 

### How to test the Change
1. Run the e2e test using GitHub action to test this PR.
2. Do thorough manual visual validation, with a strong focus on the admin interface

### Changelog Entry
> Dev - Bump WordPress "tested up to" version 7.0.
> Dev - Bump WordPress minimum supported version to 6.6.

### Credits
Props @qasumitbagthariya @iamdharmesh 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
