### PR TITLE
[Simple Analytics] Accessibility

### DIFF
--- a/assets/css/analytics.scss
+++ b/assets/css/analytics.scss
@@ -22,7 +22,7 @@ body.mailchimp_page_mailchimp_sf_analytics {
 // while keeping it readable by assistive tech. Defined locally so the
 // styles still apply if WP core's stylesheet load order changes.
 // -----------------------------------------------------------------------------
-.screen-reader-text {
+.mailchimp_page_mailchimp_sf_analytics .screen-reader-text {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
@@ -45,7 +45,8 @@ body.mailchimp_page_mailchimp_sf_analytics {
 .mailchimp_page_mailchimp_sf_analytics .mailchimp-sf-button:focus-visible,
 .mailchimp_page_mailchimp_sf_analytics button:focus-visible {
 	box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
-	outline: none;
+	outline: 2px solid transparent;
+	outline-offset: 2px;
 }
 
 // -----------------------------------------------------------------------------
@@ -83,7 +84,8 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		&:focus-visible {
 			border-color: var(--mailchimp-color-link, #017e89);
 			box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
-			outline: none;
+			outline: 2px solid transparent;
+			outline-offset: 2px;
 		}
 	}
 }
@@ -128,7 +130,8 @@ body.mailchimp_page_mailchimp_sf_analytics {
 	&:focus-visible {
 		border-color: var(--mailchimp-color-link, #017e89);
 		box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
-		outline: none;
+		outline: 2px solid transparent;
+		outline-offset: 2px;
 	}
 
 	.dashicons {
@@ -233,7 +236,8 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		&:focus-visible {
 			border-color: var(--mailchimp-color-link, #017e89);
 			box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
-			outline: none;
+			outline: 2px solid transparent;
+			outline-offset: 2px;
 		}
 	}
 
@@ -411,8 +415,6 @@ body.mailchimp_page_mailchimp_sf_analytics {
 
 	&.is-loading &__metric-value,
 	&.is-error &__metric-value {
-		// `#6b7280` (~4.83:1 on white) passes WCAG 1.4.3 for normal text.
-		// `--mc-sa-grey` × 0.85 opacity rendered as ~2.15:1 which fails AA.
 		color: #6b7280;
 	}
 

--- a/assets/css/analytics.scss
+++ b/assets/css/analytics.scss
@@ -16,6 +16,39 @@ body.mailchimp_page_mailchimp_sf_analytics {
 }
 
 // -----------------------------------------------------------------------------
+// Accessibility utilities
+//
+// `screen-reader-text` mirrors WP core's utility, visually hides content
+// while keeping it readable by assistive tech. Defined locally so the
+// styles still apply if WP core's stylesheet load order changes.
+// -----------------------------------------------------------------------------
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}
+
+.mailchimp-sf-analytics-filter-group__label {
+	color: #1d2327;
+	font-size: 14px;
+	font-weight: 400;
+}
+
+// Consistent keyboard-only focus ring across every interactive control on the analytics page.
+.mailchimp_page_mailchimp_sf_analytics .mailchimp-sf-button:focus-visible,
+.mailchimp_page_mailchimp_sf_analytics button:focus-visible {
+	box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
+	outline: none;
+}
+
+// -----------------------------------------------------------------------------
 // Filters toolbar
 // -----------------------------------------------------------------------------
 .mailchimp-sf-analytics-filters {
@@ -47,9 +80,9 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		min-width: 180px;
 		padding: 0 8px;
 
-		&:focus {
+		&:focus-visible {
 			border-color: var(--mailchimp-color-link, #017e89);
-			box-shadow: 0 0 0 1px var(--mailchimp-color-link, #017e89);
+			box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
 			outline: none;
 		}
 	}
@@ -92,9 +125,9 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		border-color: var(--mailchimp-color-link, #017e89);
 	}
 
-	&:focus {
+	&:focus-visible {
 		border-color: var(--mailchimp-color-link, #017e89);
-		box-shadow: 0 0 0 1px var(--mailchimp-color-link, #017e89);
+		box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
 		outline: none;
 	}
 
@@ -197,9 +230,9 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		height: 36px;
 		width: 100%;
 
-		&:focus {
+		&:focus-visible {
 			border-color: var(--mailchimp-color-link, #017e89);
-			box-shadow: 0 0 0 1px var(--mailchimp-color-link, #017e89);
+			box-shadow: 0 0 0 2px var(--mailchimp-color-link, #017e89);
 			outline: none;
 		}
 	}
@@ -378,8 +411,9 @@ body.mailchimp_page_mailchimp_sf_analytics {
 
 	&.is-loading &__metric-value,
 	&.is-error &__metric-value {
-		color: var(--mc-sa-grey);
-		opacity: 0.85;
+		// `#6b7280` (~4.83:1 on white) passes WCAG 1.4.3 for normal text.
+		// `--mc-sa-grey` × 0.85 opacity rendered as ~2.15:1 which fails AA.
+		color: #6b7280;
 	}
 
 	&__error-banner {
@@ -868,8 +902,7 @@ body.mailchimp_page_mailchimp_sf_analytics {
 		.mailchimp-sf-sa__net,
 		.mailchimp-sf-sa__legend-label,
 		.mailchimp-sf-sa__legend-value {
-			color: var(--mc-sa-grey);
-			opacity: 0.85;
+			color: #6b7280;
 		}
 
 		.mailchimp-sf-sa__legend-swatch {

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -466,8 +466,6 @@ import { __ } from '@wordpress/i18n';
 		const dataTableEl = document.getElementById('mailchimp-sf-fp-data-table');
 
 		const COLORS = {
-			// Chart palette. Values darkened from the original design tokens
-			// to meet WCAG 2.1 1.4.11
 			viewsFill: '#3B82F6',
 			viewsBorder: '#2563EB',
 			submissionsFill: '#0E9384',
@@ -477,8 +475,6 @@ import { __ } from '@wordpress/i18n';
 			text: '#6B7280',
 			// Legend chip fills — translucent version of each bar color so the
 			// legend markers match the outlined-chip style from the Figma spec.
-			// Translucent fills for the legend chips. RGB sourced from the
-			// new WCAG-compliant submissions teal (#0E9384)
 			viewsLegendFill: 'rgba(59, 130, 246, 0.35)',
 			submissionsLegendFill: 'rgba(14, 147, 132, 0.35)',
 		};
@@ -591,6 +587,15 @@ import { __ } from '@wordpress/i18n';
 			dataTableEl.appendChild(table);
 		}
 
+		/**
+		 * Empty the screen-reader data table
+		 */
+		function clearDataTable() {
+			if (dataTableEl) {
+				dataTableEl.innerHTML = '';
+			}
+		}
+
 		function destroyCharts() {
 			if (chart) {
 				chart.destroy();
@@ -629,6 +634,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showLoading() {
 			destroyCharts();
+			clearDataTable();
 			setErrorBanner(false);
 			setOverlay(STRINGS.loadingOverlay);
 			setSubtitle(STRINGS.loadingSubtitle);
@@ -637,6 +643,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showEmpty() {
 			destroyCharts();
+			clearDataTable();
 			setErrorBanner(false);
 			setOverlay(STRINGS.emptyOverlay);
 			setSubtitle(STRINGS.emptySubtitle);
@@ -645,6 +652,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showError(message) {
 			destroyCharts();
+			clearDataTable();
 			setOverlay('');
 			if (lastDetail && lastDetail.from && lastDetail.to) {
 				setSubtitle(formatRangeLabel(lastDetail.from, lastDetail.to));
@@ -1101,6 +1109,15 @@ import { __ } from '@wordpress/i18n';
 			dataTableEl.appendChild(table);
 		}
 
+		/**
+		 * Empty the screen-reader data table
+		 */
+		function clearDataTable() {
+			if (dataTableEl) {
+				dataTableEl.innerHTML = '';
+			}
+		}
+
 		function destroyCharts() {
 			if (barChart) {
 				barChart.destroy();
@@ -1143,6 +1160,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showLoading() {
 			destroyCharts();
+			clearDataTable();
 			showNotice('');
 			setErrorBanner(false);
 			setOverlay(STRINGS.loadingOverlay);
@@ -1153,6 +1171,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showEmpty() {
 			destroyCharts();
+			clearDataTable();
 			setErrorBanner(false);
 			setOverlay(STRINGS.emptyOverlay);
 			setSubtitle(STRINGS.emptySubtitle);
@@ -1162,6 +1181,7 @@ import { __ } from '@wordpress/i18n';
 
 		function showError(message) {
 			destroyCharts();
+			clearDataTable();
 			showNotice('');
 			setOverlay('');
 			// Keep subtitle showing the last attempted date range if we have one.

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -17,6 +17,14 @@ import '../css/analytics.scss';
 import { __ } from '@wordpress/i18n';
 
 (function () {
+	/**
+	 * `true` when the user has set the OS-level "Reduce motion" preference.
+	 * Used to disable Chart.js animations
+	 */
+	const PREFERS_REDUCED_MOTION =
+		typeof window.matchMedia === 'function' &&
+		window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 	const dateRangeSelect = document.getElementById('mailchimp-sf-date-range');
 	const dateFrom = document.getElementById('mailchimp-sf-date-from');
 	const dateTo = document.getElementById('mailchimp-sf-date-to');
@@ -421,6 +429,25 @@ import { __ } from '@wordpress/i18n';
 		}
 	});
 
+	// Close popover on Escape and return focus to the trigger button
+	document.addEventListener('keydown', function (e) {
+		if (e.key !== 'Escape') {
+			return;
+		}
+		if (!popover || !popover.classList.contains('is-open')) {
+			return;
+		}
+
+		const openCalendar = document.querySelector('.datepicker.active');
+		if (openCalendar) {
+			return;
+		}
+		closePopover();
+		if (trigger) {
+			trigger.focus();
+		}
+	});
+
 	/**
 	 * Forms performance over time
 	 */
@@ -436,19 +463,24 @@ import { __ } from '@wordpress/i18n';
 		const errorBannerEl = document.getElementById('mailchimp-sf-fp-error-banner');
 		const errorMessageEl = document.getElementById('mailchimp-sf-fp-error-message');
 		const retryBtnEl = document.getElementById('mailchimp-sf-fp-error-retry');
+		const dataTableEl = document.getElementById('mailchimp-sf-fp-data-table');
 
 		const COLORS = {
+			// Chart palette. Values darkened from the original design tokens
+			// to meet WCAG 2.1 1.4.11
 			viewsFill: '#3B82F6',
 			viewsBorder: '#2563EB',
-			submissionsFill: '#2DD4BF',
-			submissionsBorder: '#14B8A6',
-			rateBorder: '#EAB308',
+			submissionsFill: '#0E9384',
+			submissionsBorder: '#0B7A6E',
+			rateBorder: '#A88008',
 			gridLine: 'rgba(0, 0, 0, 0.06)',
 			text: '#6B7280',
 			// Legend chip fills — translucent version of each bar color so the
 			// legend markers match the outlined-chip style from the Figma spec.
+			// Translucent fills for the legend chips. RGB sourced from the
+			// new WCAG-compliant submissions teal (#0E9384)
 			viewsLegendFill: 'rgba(59, 130, 246, 0.35)',
-			submissionsLegendFill: 'rgba(45, 212, 191, 0.35)',
+			submissionsLegendFill: 'rgba(14, 147, 132, 0.35)',
 		};
 
 		const STRINGS = {
@@ -487,6 +519,76 @@ import { __ } from '@wordpress/i18n';
 			if (dateRangeEl) {
 				dateRangeEl.textContent = text || '';
 			}
+		}
+
+		/**
+		 * Build the visually-hidden screen-reader data table for the chart.
+		 *
+		 * @param {Array}  rows      Bucket rows from the payload.
+		 * @param {string} fromLabel Range start (Y-m-d).
+		 * @param {string} toLabel   Range end (Y-m-d).
+		 */
+		function renderDataTable(rows, fromLabel, toLabel) {
+			if (!dataTableEl) {
+				return;
+			}
+
+			const captionText = __(
+				'List performance over time: views, submissions, and conversion rate per bucket for %1$s to %2$s.',
+				'mailchimp',
+			)
+				.replace('%1$s', fromLabel)
+				.replace('%2$s', toLabel);
+
+			const headerCells = [
+				__('Period', 'mailchimp'),
+				__('Form Views', 'mailchimp'),
+				__('Submissions', 'mailchimp'),
+				__('Conversion Rate', 'mailchimp'),
+			];
+
+			const table = document.createElement('table');
+
+			const caption = document.createElement('caption');
+			caption.textContent = captionText;
+			table.appendChild(caption);
+
+			const thead = document.createElement('thead');
+			const headRow = document.createElement('tr');
+			headerCells.forEach(function (text) {
+				const th = document.createElement('th');
+				th.scope = 'col';
+				th.textContent = text;
+				headRow.appendChild(th);
+			});
+			thead.appendChild(headRow);
+			table.appendChild(thead);
+
+			const tbody = document.createElement('tbody');
+			rows.forEach(function (row) {
+				const tr = document.createElement('tr');
+
+				const rowHeader = document.createElement('th');
+				rowHeader.scope = 'row';
+				rowHeader.textContent = row.label || '';
+				tr.appendChild(rowHeader);
+
+				[
+					String(row.views || 0),
+					String(row.submissions || 0),
+					`${Number(row.conversion_rate || 0).toFixed(2)}%`,
+				].forEach(function (text) {
+					const td = document.createElement('td');
+					td.textContent = text;
+					tr.appendChild(td);
+				});
+
+				tbody.appendChild(tr);
+			});
+			table.appendChild(tbody);
+
+			dataTableEl.innerHTML = '';
+			dataTableEl.appendChild(table);
 		}
 
 		function destroyCharts() {
@@ -624,6 +726,7 @@ import { __ } from '@wordpress/i18n';
 				options: {
 					responsive: true,
 					maintainAspectRatio: false,
+					animation: PREFERS_REDUCED_MOTION ? false : undefined,
 					interaction: { mode: 'index', intersect: false },
 					plugins: {
 						legend: {
@@ -724,6 +827,7 @@ import { __ } from '@wordpress/i18n';
 			setOverlay('');
 			setState('ready');
 			renderChart(rows);
+			renderDataTable(rows, fromLabel, toLabel);
 		}
 
 		/**
@@ -847,6 +951,7 @@ import { __ } from '@wordpress/i18n';
 		const errorBannerEl = document.getElementById('mailchimp-sf-sa-error-banner');
 		const errorMessageEl = document.getElementById('mailchimp-sf-sa-error-message');
 		const retryBtnEl = document.getElementById('mailchimp-sf-sa-error-retry');
+		const dataTableEl = document.getElementById('mailchimp-sf-sa-data-table');
 
 		const COLORS = {
 			newFill: '#2b72fb',
@@ -926,6 +1031,74 @@ import { __ } from '@wordpress/i18n';
 			if (dateRangeEl) {
 				dateRangeEl.textContent = text || '';
 			}
+		}
+
+		/**
+		 * Build the visually-hidden screen-reader data table for the
+		 * subscriber activity chart
+		 *
+		 * @param {Array}  rows      Bucket rows from the payload.
+		 * @param {string} fromLabel Range start (Y-m-d).
+		 * @param {string} toLabel   Range end (Y-m-d).
+		 */
+		function renderDataTable(rows, fromLabel, toLabel) {
+			if (!dataTableEl) {
+				return;
+			}
+
+			const captionText = __(
+				'Subscriber change over time: new subscribers and unsubscribes per bucket for %1$s to %2$s.',
+				'mailchimp',
+			)
+				.replace('%1$s', fromLabel)
+				.replace('%2$s', toLabel);
+
+			const headerCells = [
+				__('Period', 'mailchimp'),
+				__('New Subscribers', 'mailchimp'),
+				__('Unsubscribes', 'mailchimp'),
+			];
+
+			const table = document.createElement('table');
+
+			const caption = document.createElement('caption');
+			caption.textContent = captionText;
+			table.appendChild(caption);
+
+			const thead = document.createElement('thead');
+			const headRow = document.createElement('tr');
+			headerCells.forEach(function (text) {
+				const th = document.createElement('th');
+				th.scope = 'col';
+				th.textContent = text;
+				headRow.appendChild(th);
+			});
+			thead.appendChild(headRow);
+			table.appendChild(thead);
+
+			const tbody = document.createElement('tbody');
+			rows.forEach(function (row) {
+				const tr = document.createElement('tr');
+
+				const rowHeader = document.createElement('th');
+				rowHeader.scope = 'row';
+				rowHeader.textContent = row.label || '';
+				tr.appendChild(rowHeader);
+
+				[String(row.new_subscribers || 0), String(row.unsubscribes || 0)].forEach(
+					function (text) {
+						const td = document.createElement('td');
+						td.textContent = text;
+						tr.appendChild(td);
+					},
+				);
+
+				tbody.appendChild(tr);
+			});
+			table.appendChild(tbody);
+
+			dataTableEl.innerHTML = '';
+			dataTableEl.appendChild(table);
 		}
 
 		function destroyCharts() {
@@ -1045,6 +1218,7 @@ import { __ } from '@wordpress/i18n';
 				options: {
 					responsive: true,
 					maintainAspectRatio: false,
+					animation: PREFERS_REDUCED_MOTION ? false : undefined,
 					interaction: { mode: 'index', intersect: false },
 					plugins: {
 						legend: {
@@ -1130,6 +1304,7 @@ import { __ } from '@wordpress/i18n';
 				options: {
 					responsive: true,
 					maintainAspectRatio: false,
+					animation: PREFERS_REDUCED_MOTION ? false : undefined,
 					plugins: {
 						legend: { display: false },
 						tooltip: { enabled: total > 0 },
@@ -1175,6 +1350,7 @@ import { __ } from '@wordpress/i18n';
 			renderBar(rows);
 			renderDonut(totalNew, totalUnsubs);
 			renderTotals(payload);
+			renderDataTable(rows, fromLabel, toLabel);
 		}
 
 		function fetchActivity(detail) {

--- a/includes/admin/templates/analytics.php
+++ b/includes/admin/templates/analytics.php
@@ -28,9 +28,20 @@ $dc           = get_option( 'mc_datacenter', '' );
 				<hr class="wp-header-end" />
 				<div class="mailchimp-sf-analytics-filters">
 					<div class="mailchimp-sf-analytics-filter-group">
-						<label><?php esc_html_e( 'Date range', 'mailchimp' ); ?></label>
+						<span
+							id="mailchimp-sf-date-range-label"
+							class="mailchimp-sf-analytics-filter-group__label"
+						><?php esc_html_e( 'Date range', 'mailchimp' ); ?></span>
 						<div class="mailchimp-sf-date-picker">
-							<button type="button" class="mailchimp-sf-date-picker-trigger" id="mailchimp-sf-date-picker-trigger" aria-expanded="false" aria-controls="mailchimp-sf-date-picker-popover">
+							<button
+								type="button"
+								class="mailchimp-sf-date-picker-trigger"
+								id="mailchimp-sf-date-picker-trigger"
+								aria-expanded="false"
+								aria-haspopup="dialog"
+								aria-controls="mailchimp-sf-date-picker-popover"
+								aria-labelledby="mailchimp-sf-date-range-label mailchimp-sf-date-picker-label"
+							>
 								<span id="mailchimp-sf-date-picker-label"><?php esc_html_e( 'Last 30 days', 'mailchimp' ); ?></span>
 								<div class="indicator-date-picker" aria-hidden="true">
 									<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
@@ -38,7 +49,12 @@ $dc           = get_option( 'mc_datacenter', '' );
 									</svg>
 								</div>
 							</button>
-							<div class="mailchimp-sf-date-picker-popover" id="mailchimp-sf-date-picker-popover">
+							<div
+								class="mailchimp-sf-date-picker-popover"
+								id="mailchimp-sf-date-picker-popover"
+								role="dialog"
+								aria-labelledby="mailchimp-sf-date-range-label"
+							>
 								<div class="mailchimp-sf-date-picker-popover-row">
 									<div class="mailchimp-sf-date-picker-field">
 										<label for="mailchimp-sf-date-range"><?php esc_html_e( 'Date range', 'mailchimp' ); ?></label>
@@ -263,6 +279,7 @@ $dc           = get_option( 'mc_datacenter', '' );
 									class="mailchimp-sf-fp__canvas"
 									role="img"
 									aria-label="<?php esc_attr_e( 'Form views, submissions, and conversion rate chart', 'mailchimp' ); ?>"
+									aria-describedby="mailchimp-sf-fp-data-table"
 								></canvas>
 								<div
 									id="mailchimp-sf-fp-overlay"
@@ -272,6 +289,10 @@ $dc           = get_option( 'mc_datacenter', '' );
 								><?php esc_html_e( 'Loading form performance…', 'mailchimp' ); ?></div>
 							</div>
 						</div>
+						<div
+							id="mailchimp-sf-fp-data-table"
+							class="mailchimp-sf-fp__data-table screen-reader-text"
+						></div>
 					</div>
 				</section>
 
@@ -355,6 +376,7 @@ $dc           = get_option( 'mc_datacenter', '' );
 									class="mailchimp-sf-sa__canvas"
 									role="img"
 									aria-label="<?php esc_attr_e( 'Subscriber change bar chart', 'mailchimp' ); ?>"
+									aria-describedby="mailchimp-sf-sa-data-table"
 								></canvas>
 								<div
 									id="mailchimp-sf-sa-overlay"
@@ -363,6 +385,10 @@ $dc           = get_option( 'mc_datacenter', '' );
 									aria-live="polite"
 								><?php esc_html_e( 'Loading subscriber activity…', 'mailchimp' ); ?></div>
 							</div>
+							<div
+								id="mailchimp-sf-sa-data-table"
+								class="mailchimp-sf-sa__data-table screen-reader-text"
+							></div>
 						</div>
 
 						<aside class="mailchimp-sf-sa__totals" aria-labelledby="mailchimp-sf-sa-totals-title">

--- a/includes/admin/templates/analytics.php
+++ b/includes/admin/templates/analytics.php
@@ -400,8 +400,7 @@ $dc           = get_option( 'mc_datacenter', '' );
 								<canvas
 									id="mailchimp-sf-sa-donut"
 									class="mailchimp-sf-sa__canvas"
-									role="img"
-									aria-label="<?php esc_attr_e( 'Subscriber change donut chart', 'mailchimp' ); ?>"
+									aria-hidden="true"
 								></canvas>
 								<div class="mailchimp-sf-sa__donut-center">
 									<span id="mailchimp-sf-sa-net" class="mailchimp-sf-sa__net">&mdash;</span>

--- a/tests/cypress/e2e/settings/analytics.test.js
+++ b/tests/cypress/e2e/settings/analytics.test.js
@@ -131,6 +131,20 @@ describe('Analytics admin page', () => {
 			cy.get('#mailchimp-sf-date-picker-popover').should('not.be.visible');
 		});
 
+		it('Pressing Escape closes the popover and returns focus to the trigger', () => {
+			cy.visit('/wp-admin/admin.php?page=mailchimp_sf_analytics');
+			cy.get('#mailchimp-sf-date-picker-trigger').click();
+			cy.get('#mailchimp-sf-date-picker-popover').should('be.visible');
+			cy.get('body').trigger('keydown', { key: 'Escape' });
+			cy.get('#mailchimp-sf-date-picker-popover').should('not.be.visible');
+			cy.get('#mailchimp-sf-date-picker-trigger').should('have.focus');
+			cy.get('#mailchimp-sf-date-picker-trigger').should(
+				'have.attr',
+				'aria-expanded',
+				'false',
+			);
+		});
+
 		it('List filter is present with options', () => {
 			cy.visit('/wp-admin/admin.php?page=mailchimp_sf_analytics');
 			cy.get('#mailchimp-sf-list-filter').should('exist');


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #208 

### How to test the Change
Run Lighthouse Accessibility audit in DevTools. Expect score 100.
Tab through the page. Every control shows a 2px teal ring.
Open date popover. Press Esc. Popover closes, focus returns to trigger.
DevTools Rendering panel, toggle prefers-reduced-motion: reduce. Charts snap, no animation, skeleton pulse frozen.
DevTools Elements, find #mailchimp-sf-fp-data-table and #mailchimp-sf-sa-data-table. Each contains a real table with chart data.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Switched all :focus to :focus-visible and bumped the ring from 1px to 2px.
> Added a global focus ring rule for every button on the analytics page.
> Darkened the chart Submissions color from #2DD4BF to #0E9384.
> Darkened the Conversion Rate line color from #EAB308 to #A88008.
> Updated the legend chip fill to match the new Submissions teal.
> Added PREFERS_REDUCED_MOTION check that disables Chart.js animations.
> Added a local screen-reader-text utility class.
> Replaced the muted state opacity trick with #6b7280 so the text passes WCAG 4.5:1.
> Added a screen reader data table for each chart.
> Wired both canvases to their tables via aria-describedby.
> Replaced the bare Date range <label> with a span and gave the trigger button proper aria-labelledby.
> Added aria-haspopup="dialog" on the trigger.
> Made the popover a real role="dialog" with aria-labelledby.
> Added an Escape key handler that closes the popover and returns focus to the trigger.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @alaca

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/mailchimp/wordpress/blob/develop/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
